### PR TITLE
docs: 要件と設計 baseline を確定

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -18,6 +18,8 @@ Packages/com.sunmax0731.square-crop-editor/
 
 Runtime code should contain deterministic model and image-region calculations. Editor code should handle Unity-specific asset selection, preview rendering, PNG writing, and AssetDatabase refresh.
 
+For `v0.1.0`, persistence is intentionally not part of the architecture. The EditorWindow may hold transient state, but no session JSON or preset storage should be introduced until the MVP crop and export path is stable.
+
 ## 2. Core Models
 
 ### CropSelection
@@ -43,6 +45,8 @@ Fields:
 - `OutputFolder`
 - `OutputFileName`
 - `ConflictBehavior`
+
+This model should be serializable later, but the MVP should not depend on file-backed persistence.
 
 ### SquareConversionMode
 
@@ -139,3 +143,11 @@ Preferred behavior:
 2. If not readable and asset path is readable from disk, create a temporary readable copy.
 3. Delete temporary copy after export.
 4. Report failure reason if pixels still cannot be read.
+
+## 8. MVP Implementation Boundaries
+
+- Do not introduce batch processing services.
+- Do not introduce atlas, sprite-sheet, or grid-slicing abstractions.
+- Do not add external native image-processing dependencies.
+- Do not add session or preset UI in `v0.1.0`.
+- Keep crop math testable without launching the EditorWindow.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -14,6 +14,32 @@ The tool is intended for preparing item icons, portraits, thumbnails, UI images,
 
 ## 3. Functional Requirements
 
+### MVP Scope Decision
+
+`v0.1.0` is limited to a single-image, single-selection, square-PNG export workflow.
+
+Included:
+
+- one `Texture2D` source image
+- one active crop region
+- mouse drag selection in the preview
+- square output preview
+- `Fit`, `Fill`, and `Stretch` conversion modes
+- output size selection
+- PNG export under the Unity project
+- conflict handling for existing files
+- clear validation messages for export blockers
+
+Excluded from `v0.1.0`:
+
+- batch processing
+- automatic object detection
+- masks
+- non-square export
+- atlas or grid slicing
+- permanent source importer modification
+- preset browser or session JSON save/load UI
+
 ### RQ-001 Tool Launch
 
 The user can open the tool from:
@@ -85,9 +111,14 @@ If source pixels cannot be read directly, the tool should use a temporary readab
 
 ### RQ-009 Session Persistence
 
-The MVP should decide whether session JSON is required.
+Session JSON is not part of the `v0.1.0` MVP.
 
-If implemented, it should store:
+Reason:
+
+- The first release must prove the crop selection, square conversion, preview, and export path before adding persistence.
+- Repeatability can be added after the core workflow is validated.
+
+When implemented after MVP, it should store:
 
 - source asset path
 - crop region
@@ -95,15 +126,25 @@ If implemented, it should store:
 - conversion mode
 - output folder and file name
 
-## 4. Non-Functional Requirements
+## 4. UX Requirements
+
+- The user must be able to complete the MVP workflow from one EditorWindow.
+- Controls that cannot run because required input is missing should be disabled or paired with a clear validation message.
+- The preview must prioritize direct manipulation over form-only input.
+- Export should be blocked only for hard errors such as missing source, invalid crop, invalid output size, or invalid output path.
+- Warnings such as a small selection should remain visible but should not prevent preview.
+
+## 5. Non-Functional Requirements
 
 - Unity `6000.0` or later.
 - Windows Unity Editor is the primary supported environment.
 - Editor-only package.
 - Deterministic crop math with EditMode tests.
 - UI operations should remain responsive for typical icon and portrait images.
+- The package must remain independent from Unity Grid Asset Slicer.
+- The tool must not require external image-processing dependencies for the MVP.
 
-## 5. MVP Acceptance
+## 6. MVP Acceptance
 
 - Tool opens from the Tools menu.
 - User can select a PNG texture.
@@ -111,3 +152,13 @@ If implemented, it should store:
 - User can preview a square result.
 - User can export a PNG.
 - EditMode tests cover crop math and output rect calculation.
+
+## 7. Implementation Start Criteria
+
+Implementation can move to package scaffold when:
+
+- `Fit`, `Fill`, and `Stretch` are the only MVP conversion modes.
+- Session JSON is explicitly deferred beyond `v0.1.0`.
+- Crop coordinates are defined as top-left UI-facing source pixel coordinates.
+- Export defaults are defined in the functional specification.
+- Validation scope is defined in `docs/validation-plan.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,9 @@ Acceptance:
 
 - requirements, design, and specification documents exist
 - GitHub Issues are created in Japanese
-- implementation can start from Issue 2
+- single-image, single-selection MVP scope is explicit
+- session JSON is deferred beyond `v0.1.0`
+- implementation can start from Issue 3
 
 ## P1 Core Logic
 
@@ -23,6 +25,7 @@ Acceptance:
 - package compiles in Unity
 - Runtime / Editor / Tests asmdefs exist
 - menu registration test can be added
+- package metadata matches the product name and menu path fixed in the specification
 
 ### 3. Crop Selection and Square Mapping
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -65,7 +65,11 @@ Export may still be blocked by output path or file system errors.
 
 ## 9. Session JSON Candidate
 
-If implemented in MVP, session JSON should use:
+Session JSON is deferred beyond `v0.1.0`.
+
+The MVP should keep all state in the EditorWindow session only. This avoids committing to a persistence format before the crop math, export behavior, and validation UX are proven.
+
+When persistence is added later, the candidate format is:
 
 ```json
 {
@@ -87,3 +91,26 @@ If implemented in MVP, session JSON should use:
   }
 }
 ```
+
+## 10. MVP Behavior Summary
+
+The initial implementation should behave as follows:
+
+- one source image at a time
+- one active crop selection at a time
+- visible selection overlay on the source preview
+- output preview updates from source, selection, size, and conversion mode
+- export writes a square PNG and never edits the source asset
+- `Overwrite`, `Skip`, and `Duplicate` are the initial file-conflict behaviors
+- export refreshes the AssetDatabase when the output is under `Assets/`
+
+## 11. Package Scaffold Handoff
+
+Issue #3 can start from these fixed decisions:
+
+- package path: `Packages/com.sunmax0731.square-crop-editor`
+- menu path: `Tools > Square Crop Editor > Open`
+- default output size: `256`
+- default output folder: `Assets/Generated/SquareCrop`
+- default conversion mode: `Fit`
+- MVP persistence: EditorWindow memory only

--- a/docs/validation-plan.md
+++ b/docs/validation-plan.md
@@ -13,6 +13,13 @@ Required areas:
 - Stretch mapping
 - invalid selection validation
 - output file name and conflict behavior
+- default settings for output size, folder, file name suffix, conversion mode, and conflict behavior
+
+Out of MVP automated scope:
+
+- session JSON serialization
+- preset save/load
+- batch crop export
 
 ## Manual Smoke
 
@@ -26,6 +33,16 @@ Required areas:
 8. Export to `Assets/Generated/SquareCrop`.
 9. Confirm output PNG is square and imported by Unity.
 10. Repeat with a source texture that has Read/Write disabled.
+
+## Issue #2 Baseline Check
+
+The requirements baseline is ready for implementation when:
+
+- MVP scope is limited to one source image and one crop selection.
+- `Fit`, `Fill`, and `Stretch` are the only initial conversion modes.
+- Session JSON is deferred beyond `v0.1.0`.
+- Export blockers and warnings are listed in the functional specification.
+- The next issue can create the UPM package scaffold without reopening product-scope decisions.
 
 ## Release Gate
 


### PR DESCRIPTION
## 概要
- `v0.1.0` MVP を single image / single crop / square PNG export に明確化
- `Fit` / `Fill` / `Stretch` を初期 conversion mode として固定
- session JSON / preset UI を MVP 外へ延期
- Issue #3 の package scaffold に渡す固定条件を追記

## 検証
- `rg` で未決定文言を確認
- docs 差分確認のみ（コード実装なし）

Closes #2