### PR TITLE
feat: package scaffold を追加

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 170c6e6cf2a38f142a3628f6852ed3c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Sunmax0731.SquareCropEditor.Editor.asmdef
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Sunmax0731.SquareCropEditor.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "Sunmax0731.SquareCropEditor.Editor",
+  "rootNamespace": "Sunmax0731.SquareCropEditor.Editor",
+  "references": [
+    "Sunmax0731.SquareCropEditor.Runtime"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Sunmax0731.SquareCropEditor.Editor.asmdef.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Sunmax0731.SquareCropEditor.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5fa91f8e7707dc54dbbccdf322573f34
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdf1c724cee45bf49b37bc5e2742d8d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -1,0 +1,25 @@
+using Sunmax0731.SquareCropEditor.Services;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Editor.Windows
+{
+    public sealed class SquareCropEditorWindow : EditorWindow
+    {
+        public const string WindowTitle = "Square Crop Editor";
+
+        [MenuItem(SquareCropDefaults.MenuPath)]
+        public static void Open()
+        {
+            var window = GetWindow<SquareCropEditorWindow>();
+            window.titleContent = new GUIContent(WindowTitle);
+            window.Show();
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField(WindowTitle, EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("Package scaffold is ready. Crop UI implementation starts from the next issues.", MessageType.Info);
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b5bd7c21c3f48149881037e0f066548

--- a/Packages/com.sunmax0731.square-crop-editor/README.md
+++ b/Packages/com.sunmax0731.square-crop-editor/README.md
@@ -1,0 +1,27 @@
+# Unity Square Crop Editor
+
+Unity Square Crop Editor is a Unity Editor extension for selecting a region of a `Texture2D` asset and exporting the selected region as a square PNG.
+
+## MVP Scope
+
+- Open from `Tools > Square Crop Editor > Open`.
+- Select one source image.
+- Drag one crop region.
+- Preview a square output.
+- Export a square PNG.
+
+Batch export, grid slicing, automatic detection, masks, and session JSON persistence are outside the `v0.1.0` MVP.
+
+## Package Layout
+
+```text
+Runtime/
+  Models/
+  Services/
+Editor/
+  Windows/
+Tests/
+  Editor/
+```
+
+Runtime code should stay deterministic and testable. Editor code should handle Unity menu integration, windows, asset selection, export, and AssetDatabase refresh.

--- a/Packages/com.sunmax0731.square-crop-editor/README.md.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29caab88726b3b243a6d574c2b7dc378
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d42828dd1f63e94295598ec78982f1e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c2b4c340f549224abb37d2f4fded257
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CropSelection.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CropSelection.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public readonly struct CropSelection
+    {
+        public CropSelection(int x, int y, int width, int height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public int X { get; }
+
+        public int Y { get; }
+
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public bool IsValid => Width > 0 && Height > 0;
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CropSelection.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CropSelection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e01746dd9bd325948a72aef0ddb7afe3

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/ExportConflictBehavior.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/ExportConflictBehavior.cs
@@ -1,0 +1,9 @@
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    public enum ExportConflictBehavior
+    {
+        Overwrite = 0,
+        Skip = 1,
+        Duplicate = 2
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/ExportConflictBehavior.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/ExportConflictBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b38821a24c08a34986d78a1b292ae5f

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs
@@ -1,0 +1,9 @@
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    public enum SquareConversionMode
+    {
+        Fit = 0,
+        Fill = 1,
+        Stretch = 2
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45b9ef22902c02640bd883a06fb13ce4

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public sealed class SquareCropSettings
+    {
+        public const int DefaultOutputSize = 256;
+        public const string DefaultOutputFolder = "Assets/Generated/SquareCrop";
+        public const string DefaultFileNameSuffix = "_crop";
+
+        public int OutputSize { get; set; } = DefaultOutputSize;
+
+        public SquareConversionMode ConversionMode { get; set; } = SquareConversionMode.Fit;
+
+        public string OutputFolder { get; set; } = DefaultOutputFolder;
+
+        public string OutputFileName { get; set; } = string.Empty;
+
+        public ExportConflictBehavior ConflictBehavior { get; set; } = ExportConflictBehavior.Duplicate;
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c13660c73632984789bc0184143338d

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d13a8daac8fa2474da6111b71f7f926e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/SquareCropDefaults.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/SquareCropDefaults.cs
@@ -1,0 +1,14 @@
+using Sunmax0731.SquareCropEditor.Models;
+
+namespace Sunmax0731.SquareCropEditor.Services
+{
+    public static class SquareCropDefaults
+    {
+        public const string MenuPath = "Tools/Square Crop Editor/Open";
+
+        public static SquareCropSettings CreateSettings()
+        {
+            return new SquareCropSettings();
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/SquareCropDefaults.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/SquareCropDefaults.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bcb107d243940d4c9d1d670efdb09ee

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Sunmax0731.SquareCropEditor.Runtime.asmdef
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Sunmax0731.SquareCropEditor.Runtime.asmdef
@@ -1,0 +1,14 @@
+{
+  "name": "Sunmax0731.SquareCropEditor.Runtime",
+  "rootNamespace": "Sunmax0731.SquareCropEditor",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Sunmax0731.SquareCropEditor.Runtime.asmdef.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Sunmax0731.SquareCropEditor.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4783a336fb93fcf4b9c94ee399509080
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Tests.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42a5294277c0ead4a8c87061c93af4cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0874d37973e1842438ff6c9d515f46f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using Sunmax0731.SquareCropEditor.Models;
+using Sunmax0731.SquareCropEditor.Services;
+
+namespace Sunmax0731.SquareCropEditor.Tests.Editor
+{
+    public sealed class SquareCropPackageScaffoldTests
+    {
+        [Test]
+        public void DefaultsMatchRequirementsBaseline()
+        {
+            var settings = SquareCropDefaults.CreateSettings();
+
+            Assert.That(SquareCropDefaults.MenuPath, Is.EqualTo("Tools/Square Crop Editor/Open"));
+            Assert.That(settings.OutputSize, Is.EqualTo(256));
+            Assert.That(settings.OutputFolder, Is.EqualTo("Assets/Generated/SquareCrop"));
+            Assert.That(settings.ConversionMode, Is.EqualTo(SquareConversionMode.Fit));
+            Assert.That(settings.ConflictBehavior, Is.EqualTo(ExportConflictBehavior.Duplicate));
+        }
+
+        [Test]
+        public void CropSelectionRequiresPositiveSize()
+        {
+            Assert.That(new CropSelection(0, 0, 1, 1).IsValid, Is.True);
+            Assert.That(new CropSelection(0, 0, 0, 1).IsValid, Is.False);
+            Assert.That(new CropSelection(0, 0, 1, 0).IsValid, Is.False);
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d3a2847aeaa27843bac9d5ba1c8f63d

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/Sunmax0731.SquareCropEditor.Editor.Tests.asmdef
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/Sunmax0731.SquareCropEditor.Editor.Tests.asmdef
@@ -1,0 +1,22 @@
+{
+  "name": "Sunmax0731.SquareCropEditor.Editor.Tests",
+  "rootNamespace": "Sunmax0731.SquareCropEditor.Tests.Editor",
+  "references": [
+    "Sunmax0731.SquareCropEditor.Runtime",
+    "Sunmax0731.SquareCropEditor.Editor"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": false,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
+  "noEngineReferences": false
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/Sunmax0731.SquareCropEditor.Editor.Tests.asmdef.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/Sunmax0731.SquareCropEditor.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 666deef3a7ba5fe4f8879ec3615e5af8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.sunmax0731.square-crop-editor/package.json
+++ b/Packages/com.sunmax0731.square-crop-editor/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "com.sunmax0731.square-crop-editor",
+  "displayName": "Unity Square Crop Editor",
+  "version": "0.1.0",
+  "unity": "6000.0",
+  "description": "Unity Editor extension for drag-selecting an image region and exporting it as a square PNG.",
+  "keywords": [
+    "editor",
+    "texture",
+    "crop",
+    "png",
+    "square"
+  ],
+  "author": {
+    "name": "Sunmax0731",
+    "url": "https://github.com/Sunmax0731"
+  }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/package.json.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 37c5a874375d0fc4192760a3c48c75bb
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
- `Packages/com.sunmax0731.square-crop-editor` の UPM package metadata を追加
- Runtime / Editor / Tests の asmdef と Unity meta を追加
- MVP baseline に沿った `CropSelection` / `SquareCropSettings` / conversion mode / conflict behavior を追加
- `Tools > Square Crop Editor > Open` に対応する EditorWindow menu entry を追加
- scaffold 確認用 EditMode test assembly と初期テストを追加

## 検証
- 一時 Unity project から package を `file:` 参照
- Unity `6000.4.0f1` batchmode で package import と script compilation 成功
- `Library/ScriptAssemblies` に Runtime / Editor / Editor.Tests DLL 生成を確認
- 注意: `-runTests` は exit code 0 で終了したが `-testResults` XML を出力しなかったため、現時点では compile scaffold の検証として扱う

Closes #3