### PR TITLE
docs: 透過PNGとアスペクト比要件を反映

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/README.md
+++ b/Packages/com.sunmax0731.square-crop-editor/README.md
@@ -1,14 +1,14 @@
 # Unity Square Crop Editor
 
-Unity Square Crop Editor is a Unity Editor extension for selecting a region of a `Texture2D` asset and exporting the selected region as a square PNG.
+Unity Square Crop Editor is a Unity Editor extension for selecting a region of a transparent `Texture2D` asset and exporting the selected region as a PNG with a configurable aspect ratio. Square is the default ratio.
 
 ## MVP Scope
 
 - Open from `Tools > Square Crop Editor > Open`.
 - Select one source image.
-- Drag one crop region.
-- Preview a square output.
-- Export a square PNG.
+- Drag one crop region constrained by square, preset aspect ratio, or custom numeric ratio.
+- Preview transparent PNG output.
+- Export PNG with the selected output aspect ratio.
 
 Batch export, grid slicing, automatic detection, masks, and session JSON persistence are outside the `v0.1.0` MVP.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unity Square Crop Editor
 
-Unity Square Crop Editor is a planned Unity Editor extension for selecting an area of an image by drag operation, cropping that area, and exporting it as a square PNG.
+Unity Square Crop Editor is a planned Unity Editor extension for selecting an area of a transparent image by drag operation, cropping that area, and exporting it as a PNG with a configurable aspect ratio. The default selection and output ratio is square.
 
 This repository starts from requirements and design work. Implementation should proceed issue by issue after the product behavior, data model, and validation strategy are agreed.
 
@@ -9,8 +9,8 @@ This repository starts from requirements and design work. Implementation should 
 - Open a Unity Editor tool window from the Tools menu.
 - Select a source image asset.
 - Drag on the image preview to choose a crop region.
-- Convert the selected region into a square image.
-- Export the result as PNG without modifying the original source asset.
+- Convert the selected region into a configurable output aspect ratio.
+- Preserve source alpha and export the result as PNG without modifying the original source asset.
 - Keep the workflow separate from Unity Grid Asset Slicer.
 
 ## Documents
@@ -26,9 +26,9 @@ This repository starts from requirements and design work. Implementation should 
 `v0.1.0` focuses on a single-image, single-crop workflow:
 
 1. Select source image.
-2. Drag to select crop region.
-3. Preview square output.
-4. Choose square size and padding or fit mode.
+2. Drag to select a crop region constrained by square, preset aspect ratio, or custom numeric ratio.
+3. Preview transparent PNG output.
+4. Choose output aspect ratio, output size, and fit/fill/stretch mode.
 5. Export PNG.
 
-Batch processing, automatic object detection, masks, and non-square exports are out of scope for the first release.
+Batch processing, automatic object detection, masks, and atlas or grid slicing are out of scope for the first release.

--- a/docs/design.md
+++ b/docs/design.md
@@ -33,6 +33,26 @@ Fields:
 - `Width`
 - `Height`
 
+The crop region is the committed pixel rectangle after drag normalization, source-bound clamping, and active crop aspect ratio constraint.
+
+### AspectRatioSpec
+
+Represents a user-selectable ratio.
+
+Fields:
+
+- `Mode` (`Preset` or `Custom`)
+- `Width`
+- `Height`
+
+Initial presets:
+
+- `1:1`
+- `4:3`
+- `3:4`
+- `16:9`
+- `9:16`
+
 ### SquareCropSettings
 
 Represents output configuration.
@@ -40,15 +60,16 @@ Represents output configuration.
 Fields:
 
 - `OutputSize`
+- `CropAspectRatio`
+- `OutputAspectRatio`
 - `ConversionMode`
-- `PaddingColor`
 - `OutputFolder`
 - `OutputFileName`
 - `ConflictBehavior`
 
 This model should be serializable later, but the MVP should not depend on file-backed persistence.
 
-### SquareConversionMode
+### CanvasMappingMode
 
 Initial values:
 
@@ -66,28 +87,32 @@ Responsibilities:
 
 - account for preview scaling
 - clamp selection to source image bounds
+- apply the active crop aspect ratio during drag
 - normalize drag direction
 - reject zero-sized regions
 
-### SquareOutputPlanner
+### AspectOutputPlanner
 
-Calculates how the selected region maps onto the square output canvas.
+Calculates how the selected region maps onto the configured output canvas.
 
 Responsibilities:
 
-- fit/fill/stretch source rect
+- derive output width and height from long edge size and output aspect ratio
+- fit/fill/stretch source rect onto the output canvas
 - calculate destination rect
 - calculate transparent padding
 - return warnings when selection is too small or invalid
 
-### PngSquareExporter
+### PngAspectExporter
 
-Exports the selected region as a PNG.
+Exports the selected region as a transparent PNG.
 
 Responsibilities:
 
 - read pixels
-- resample into square texture
+- resample into configured output dimensions
+- preserve source alpha
+- keep padding pixels transparent
 - encode PNG
 - write file
 - return exported/skipped/error result
@@ -102,15 +127,16 @@ Toolbar:
 
 Left pane:
   Source
+  Selection Aspect Ratio
   Crop Settings
   Output
 
 Center pane:
   Source image preview
-  draggable selection overlay
+  draggable ratio-constrained selection overlay
 
 Right pane:
-  Square output preview
+  transparent output preview
   selection details
   validation report
 ```
@@ -120,18 +146,28 @@ Right pane:
 - Mouse down starts selection.
 - Drag updates selection.
 - Mouse up commits selection.
-- Shift-drag may constrain selection to square in source space as a future option.
+- The active crop aspect ratio constrains the selection during drag.
+- The default active crop aspect ratio is square.
+- Ratio preset and custom numeric controls should update the active selection when possible.
 - Escape may clear active selection as a future option.
 
 ## 6. Output Behavior
 
-The source selection may be rectangular, but exported output is always square.
+The source selection and exported output each have an aspect ratio.
+
+The default for both is square (`1:1`), but the user can select presets or enter a custom numeric ratio for each.
 
 Mode behavior:
 
-- `Fit`: no source pixels are lost; unused square area is transparent or padding color.
-- `Fill`: square is filled; source region may be cropped.
-- `Stretch`: direct scale; aspect ratio may change.
+- `Fit`: no source pixels are lost; unused output canvas area is transparent.
+- `Fill`: output canvas is filled; source region may be cropped.
+- `Stretch`: direct scale to output dimensions; aspect ratio may change.
+
+Alpha behavior:
+
+- Source alpha is preserved during resampling.
+- Empty output canvas pixels are transparent.
+- The MVP does not include a solid background or matte color.
 
 ## 7. Readability Strategy
 
@@ -151,3 +187,4 @@ Preferred behavior:
 - Do not add external native image-processing dependencies.
 - Do not add session or preset UI in `v0.1.0`.
 - Keep crop math testable without launching the EditorWindow.
+- Keep alpha handling explicit in planner/exporter tests.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,29 +2,32 @@
 
 ## 1. Purpose
 
-Unity Square Crop Editor is a Unity Editor extension that lets a user drag-select an area of an image, crop that area, and output a square PNG.
+Unity Square Crop Editor is a Unity Editor extension that lets a user drag-select an area of a transparent image, crop that area, and output a transparent PNG. The default selection and output shape is square, but both can use preset or custom numeric aspect ratios.
 
-The tool is intended for preparing item icons, portraits, thumbnails, UI images, and generated image fragments that need a consistent square format.
+The tool is intended for preparing item icons, portraits, thumbnails, UI images, and generated image fragments that need a consistent transparent PNG format.
 
 ## 2. Users
 
 - Unity developers preparing project assets.
-- Game developers creating square item icons or character portraits.
+- Game developers creating item icons, character portraits, and UI images with consistent aspect ratios.
 - Users who generate larger images and need to crop useful regions inside Unity.
 
 ## 3. Functional Requirements
 
 ### MVP Scope Decision
 
-`v0.1.0` is limited to a single-image, single-selection, square-PNG export workflow.
+`v0.1.0` is limited to a single-image, single-selection, transparent PNG export workflow.
 
 Included:
 
 - one `Texture2D` source image
+- transparent background source image assumption
 - one active crop region
 - mouse drag selection in the preview
-- square output preview
-- `Fit`, `Fill`, and `Stretch` conversion modes
+- crop selection aspect ratio controls with square default
+- output aspect ratio controls with square default
+- transparent output preview
+- `Fit`, `Fill`, and `Stretch` canvas mapping modes
 - output size selection
 - PNG export under the Unity project
 - conflict handling for existing files
@@ -35,7 +38,6 @@ Excluded from `v0.1.0`:
 - batch processing
 - automatic object detection
 - masks
-- non-square export
 - atlas or grid slicing
 - permanent source importer modification
 - preset browser or session JSON save/load UI
@@ -52,7 +54,9 @@ Tools > Square Crop Editor > Open
 
 The user can select a Unity `Texture2D` asset as the source image.
 
-The tool must show the asset path, pixel size, and readability status.
+The source image is assumed to use transparency for the background.
+
+The tool must show the asset path, pixel size, readability status, and whether the source format has an alpha channel when that can be detected.
 
 ### RQ-003 Drag Selection
 
@@ -60,15 +64,39 @@ The user can drag over the image preview to define a rectangular crop region.
 
 The selected region must be visible with an outline and optional dimmed outside area.
 
-### RQ-004 Square Output
+The selection shape must be constrained by a crop aspect ratio setting.
 
-The crop result is exported as a square PNG.
+Initial crop aspect ratio options:
 
-The tool must support at least these square conversion modes:
+- `1:1` square default
+- `4:3`
+- `3:4`
+- `16:9`
+- `9:16`
+- custom numeric width and height ratio, both positive
 
-- `Fit`: fit the selected region inside a square canvas, preserving aspect ratio and adding transparent padding.
-- `Fill`: fill the square canvas, preserving aspect ratio and cropping overflow.
-- `Stretch`: stretch the selected region to the square size.
+The active ratio should affect drag behavior directly, so the committed crop selection matches the chosen ratio after clamping to source bounds.
+
+### RQ-004 Output Aspect Ratio
+
+The crop result is exported as a PNG with a configurable output aspect ratio.
+
+The output aspect ratio uses the same kind of options as crop selection:
+
+- `1:1` square default
+- `4:3`
+- `3:4`
+- `16:9`
+- `9:16`
+- custom numeric width and height ratio, both positive
+
+The crop selection ratio and output ratio are independent settings. They may be the same, but the user must be able to change each setting separately.
+
+The tool must support at least these canvas mapping modes:
+
+- `Fit`: fit the selected region inside the output canvas, preserving aspect ratio and adding transparent padding.
+- `Fill`: fill the output canvas, preserving aspect ratio and cropping overflow.
+- `Stretch`: stretch the selected region to the output canvas dimensions.
 
 ### RQ-005 Output Size
 
@@ -82,19 +110,23 @@ Initial supported sizes:
 - 512
 - custom positive integer
 
+For non-square output, the selected size represents the long edge. The short edge is derived from the output aspect ratio and rounded to the nearest positive integer. For `1:1`, width and height are equal.
+
 ### RQ-006 Preview
 
 The tool shows:
 
 - source image preview
 - selected crop region
-- square output preview
+- transparent output preview
 
-The output preview must update when crop region, output size, or conversion mode changes.
+The output preview must update when crop region, crop aspect ratio, output aspect ratio, output size, or mapping mode changes.
+
+The preview should use a checkerboard or equivalent editor pattern so transparent pixels are visually distinguishable.
 
 ### RQ-007 Export
 
-The user can export the square PNG to a project-relative folder.
+The user can export the PNG to a project-relative folder.
 
 The tool must support:
 
@@ -109,7 +141,18 @@ The source texture importer settings must not be permanently changed without exp
 
 If source pixels cannot be read directly, the tool should use a temporary readable copy or provide a clear recovery path.
 
-### RQ-009 Session Persistence
+### RQ-009 Alpha Preservation
+
+The output image background must remain transparent.
+
+Rules:
+
+- Source pixel alpha must be preserved during crop and resampling.
+- Empty canvas areas, including `Fit` padding, must be transparent.
+- The MVP must not composite the output onto a solid background.
+- Output PNG alpha values depend on the original image pixels and transparent padding, not on a user-selected matte color.
+
+### RQ-010 Session Persistence
 
 Session JSON is not part of the `v0.1.0` MVP.
 
@@ -122,6 +165,8 @@ When implemented after MVP, it should store:
 
 - source asset path
 - crop region
+- crop aspect ratio
+- output aspect ratio
 - output size
 - conversion mode
 - output folder and file name
@@ -149,16 +194,18 @@ When implemented after MVP, it should store:
 - Tool opens from the Tools menu.
 - User can select a PNG texture.
 - User can drag-select a region on the preview.
-- User can preview a square result.
+- User can preview a transparent result.
 - User can export a PNG.
-- EditMode tests cover crop math and output rect calculation.
+- EditMode tests cover crop math, aspect ratio constraints, alpha-preserving output planning, and output rect calculation.
 
-## 7. Implementation Start Criteria
+## 7. Aspect-Aware Implementation Start Criteria
 
-Implementation can move to package scaffold when:
+Implementation can move to crop selection and aspect mapping when:
 
-- `Fit`, `Fill`, and `Stretch` are the only MVP conversion modes.
+- `Fit`, `Fill`, and `Stretch` are the only MVP canvas mapping modes.
+- Crop and output aspect ratios both support square default, presets, and custom numeric ratios.
 - Session JSON is explicitly deferred beyond `v0.1.0`.
 - Crop coordinates are defined as top-left UI-facing source pixel coordinates.
+- Source alpha preservation and transparent padding behavior are defined.
 - Export defaults are defined in the functional specification.
 - Validation scope is defined in `docs/validation-plan.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,8 @@ Acceptance:
 
 - requirements, design, and specification documents exist
 - GitHub Issues are created in Japanese
-- single-image, single-selection MVP scope is explicit
+- single-image, single-selection transparent PNG MVP scope is explicit
+- crop and output aspect ratio requirements are explicit
 - session JSON is deferred beyond `v0.1.0`
 - implementation can start from Issue 3
 
@@ -27,23 +28,27 @@ Acceptance:
 - menu registration test can be added
 - package metadata matches the product name and menu path fixed in the specification
 
-### 3. Crop Selection and Square Mapping
+### 3. Crop Selection and Aspect Mapping
 
-Goal: implement pure C# crop rectangle and square mapping logic.
+Goal: implement pure C# crop rectangle and aspect-ratio mapping logic.
 
 Acceptance:
 
 - drag normalization is tested
 - source-bound clamping is tested
+- crop aspect ratio constraints are tested
+- output dimension derivation is tested
 - Fit / Fill / Stretch mapping is tested
 
 ### 4. PNG Export Service
 
-Goal: export selected region to a square PNG.
+Goal: export selected region to a transparent PNG with the configured output aspect ratio.
 
 Acceptance:
 
-- output size is respected
+- output size and aspect ratio are respected
+- source alpha is preserved
+- transparent padding remains transparent
 - Fit / Fill / Stretch produce expected dimensions
 - conflict behavior is tested
 
@@ -51,13 +56,13 @@ Acceptance:
 
 ### 5. Editor Window MVP
 
-Goal: implement source selection, drag preview, output preview, and export UI.
+Goal: implement source selection, ratio-constrained drag preview, output preview, and export UI.
 
 Acceptance:
 
 - source image can be selected
-- drag selection appears on image
-- square preview updates
+- drag selection appears on image with the selected crop aspect ratio
+- transparent output preview updates
 - export writes PNG under `Assets/`
 
 ### 6. Readability and Validation UX

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -22,15 +22,27 @@ Unity texture operations may use bottom-left origin internally, but public UI an
 - Selection is clamped to source bounds.
 - Minimum valid selection is `1 x 1` pixel.
 - If the source image is missing, selection controls are disabled.
+- Crop selection is constrained by the active crop aspect ratio.
+- Default crop aspect ratio is `1:1`.
+- Preset crop ratios are `1:1`, `4:3`, `3:4`, `16:9`, and `9:16`.
+- Custom crop ratio uses positive numeric `width` and `height` values.
 
 ## 5. Output Rules
 
 - Output is always PNG.
-- Output canvas is always square.
+- Output canvas aspect ratio is configurable.
+- Default output aspect ratio is `1:1`.
+- Preset output ratios are `1:1`, `4:3`, `3:4`, `16:9`, and `9:16`.
+- Custom output ratio uses positive numeric `width` and `height` values.
 - Output size must be a positive integer.
+- Output size means long edge length for non-square ratios.
+- Output short edge is derived from output aspect ratio and rounded to the nearest positive integer.
 - Recommended default output size: `256`.
 - Default output folder: `Assets/Generated/SquareCrop`.
 - Default output name: source file name plus `_crop`.
+- Source alpha must be preserved.
+- Canvas padding must be transparent.
+- The MVP does not support solid matte background fill.
 
 ## 6. Conflict Behavior
 
@@ -50,6 +62,8 @@ Validation should report:
 - source texture cannot be read
 - no crop region selected
 - crop region has invalid size
+- crop aspect ratio is invalid
+- output aspect ratio is invalid
 - output size is invalid
 - output folder is invalid
 - output file name is invalid
@@ -59,9 +73,11 @@ Validation warnings should not prevent preview when a usable crop region exists.
 
 ## 8. Quality and Preview
 
-The output preview should render even if export settings are incomplete, as long as source image and crop region are valid.
+The output preview should render even if export settings are incomplete, as long as source image, crop region, output aspect ratio, and output size are valid.
 
 Export may still be blocked by output path or file system errors.
+
+Transparent pixels should be shown over a checkerboard or equivalent editor preview background.
 
 ## 9. Session JSON Candidate
 
@@ -81,10 +97,20 @@ When persistence is added later, the candidate format is:
     "x": 0,
     "y": 0,
     "width": 128,
-    "height": 96
+    "height": 128,
+    "aspectRatio": {
+      "mode": "Preset",
+      "width": 1,
+      "height": 1
+    }
   },
   "output": {
     "size": 256,
+    "aspectRatio": {
+      "mode": "Preset",
+      "width": 1,
+      "height": 1
+    },
     "mode": "Fit",
     "folder": "Assets/Generated/SquareCrop",
     "fileName": "source_crop.png"
@@ -98,9 +124,11 @@ The initial implementation should behave as follows:
 
 - one source image at a time
 - one active crop selection at a time
+- transparent source image assumption
+- crop selection constrained by square, preset ratio, or custom numeric ratio
 - visible selection overlay on the source preview
-- output preview updates from source, selection, size, and conversion mode
-- export writes a square PNG and never edits the source asset
+- output preview updates from source, selection, output aspect ratio, size, and mapping mode
+- export writes an alpha-preserving PNG and never edits the source asset
 - `Overwrite`, `Skip`, and `Duplicate` are the initial file-conflict behaviors
 - export refreshes the AssetDatabase when the output is under `Assets/`
 
@@ -111,6 +139,8 @@ Issue #3 can start from these fixed decisions:
 - package path: `Packages/com.sunmax0731.square-crop-editor`
 - menu path: `Tools > Square Crop Editor > Open`
 - default output size: `256`
+- default crop aspect ratio: `1:1`
+- default output aspect ratio: `1:1`
 - default output folder: `Assets/Generated/SquareCrop`
-- default conversion mode: `Fit`
+- default canvas mapping mode: `Fit`
 - MVP persistence: EditorWindow memory only

--- a/docs/validation-plan.md
+++ b/docs/validation-plan.md
@@ -8,10 +8,16 @@ Required areas:
 
 - drag coordinate normalization
 - source bounds clamping
+- crop aspect ratio presets and custom numeric ratio
+- output aspect ratio presets and custom numeric ratio
+- output width/height derivation from long edge size
 - Fit mapping
 - Fill mapping
 - Stretch mapping
+- source alpha preservation
+- transparent padding behavior
 - invalid selection validation
+- invalid aspect ratio validation
 - output file name and conflict behavior
 - default settings for output size, folder, file name suffix, conversion mode, and conflict behavior
 
@@ -26,23 +32,28 @@ Out of MVP automated scope:
 1. Open Unity project.
 2. Open `Tools > Square Crop Editor > Open`.
 3. Select a PNG source image.
-4. Drag a rectangular region.
-5. Confirm selected region outline is visible.
-6. Confirm square output preview updates.
-7. Test `Fit`, `Fill`, and `Stretch`.
-8. Export to `Assets/Generated/SquareCrop`.
-9. Confirm output PNG is square and imported by Unity.
-10. Repeat with a source texture that has Read/Write disabled.
+4. Select crop aspect ratio: default square, then at least one non-square preset.
+5. Drag a region.
+6. Confirm selected region outline follows the chosen crop aspect ratio.
+7. Select output aspect ratio: default square, then at least one non-square preset.
+8. Confirm transparent output preview updates.
+9. Test `Fit`, `Fill`, and `Stretch`.
+10. Export to `Assets/Generated/SquareCrop`.
+11. Confirm output PNG dimensions match output aspect ratio.
+12. Confirm transparent pixels remain transparent.
+13. Repeat with a source texture that has Read/Write disabled.
 
-## Issue #2 Baseline Check
+## Aspect Requirement Baseline Check
 
 The requirements baseline is ready for implementation when:
 
-- MVP scope is limited to one source image and one crop selection.
-- `Fit`, `Fill`, and `Stretch` are the only initial conversion modes.
+- MVP scope is limited to one transparent source image and one crop selection.
+- Crop and output aspect ratios both support square default, presets, and custom numeric ratios.
+- `Fit`, `Fill`, and `Stretch` are the only initial canvas mapping modes.
+- Alpha preservation and transparent padding behavior are specified.
 - Session JSON is deferred beyond `v0.1.0`.
 - Export blockers and warnings are listed in the functional specification.
-- The next issue can create the UPM package scaffold without reopening product-scope decisions.
+- Crop selection and aspect mapping can be implemented without reopening product-scope decisions.
 
 ## Release Gate
 


### PR DESCRIPTION
## 概要
- 入力画像を透過背景前提として明記
- source alpha preservation と transparent padding の要件を追加
- crop selection aspect ratio を square default / presets / custom numeric ratio に拡張
- output aspect ratio も square default / presets / custom numeric ratio に拡張
- `Fit` / `Fill` / `Stretch` を square conversion ではなく canvas mapping mode として整理
- README / requirements / specification / design / roadmap / validation plan を同期

## Issue 更新
- #4 を crop selection と aspect mapping 実装に更新
- #5 を aspect-aware transparent PNG export 実装に更新
- #6 を aspect controls と transparent preview を持つ Editor Window MVP に更新

## 検証
- `rg` で古い正方形固定表現を確認
- docs 差分確認のみ（要件定義更新、コード実装なし）

Closes #13