### PR TITLE
feat: aspect crop mapping logic を追加

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/AspectRatioSpec.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/AspectRatioSpec.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public readonly struct AspectRatioSpec
+    {
+        public static readonly AspectRatioSpec Square = new AspectRatioSpec(1, 1);
+        public static readonly AspectRatioSpec Landscape4By3 = new AspectRatioSpec(4, 3);
+        public static readonly AspectRatioSpec Portrait3By4 = new AspectRatioSpec(3, 4);
+        public static readonly AspectRatioSpec Landscape16By9 = new AspectRatioSpec(16, 9);
+        public static readonly AspectRatioSpec Portrait9By16 = new AspectRatioSpec(9, 16);
+
+        public AspectRatioSpec(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public bool IsValid => Width > 0 && Height > 0;
+
+        public double Value
+        {
+            get
+            {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Aspect ratio width and height must be positive.");
+                }
+
+                return (double)Width / Height;
+            }
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/AspectRatioSpec.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/AspectRatioSpec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c128515f0cc505f4ba8a096d2ebff434

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CanvasMappingMode.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CanvasMappingMode.cs
@@ -1,6 +1,6 @@
 namespace Sunmax0731.SquareCropEditor.Models
 {
-    public enum SquareConversionMode
+    public enum CanvasMappingMode
     {
         Fit = 0,
         Fill = 1,

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CanvasMappingMode.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/CanvasMappingMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 35c167d8f08be0b499d4793d3aa09d97

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/OutputMappingPlan.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/OutputMappingPlan.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public readonly struct OutputMappingPlan
+    {
+        public OutputMappingPlan(PixelSize outputSize, CropSelection sourceRect, CropSelection destinationRect, CanvasMappingMode mappingMode)
+        {
+            OutputSize = outputSize;
+            SourceRect = sourceRect;
+            DestinationRect = destinationRect;
+            MappingMode = mappingMode;
+        }
+
+        public PixelSize OutputSize { get; }
+
+        public CropSelection SourceRect { get; }
+
+        public CropSelection DestinationRect { get; }
+
+        public CanvasMappingMode MappingMode { get; }
+
+        public bool IsValid => OutputSize.IsValid && SourceRect.IsValid && DestinationRect.IsValid;
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/OutputMappingPlan.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/OutputMappingPlan.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fa21f8e840afda4abdf91f9eb38800d

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PixelSize.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PixelSize.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public readonly struct PixelSize
+    {
+        public PixelSize(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public int Width { get; }
+
+        public int Height { get; }
+
+        public bool IsValid => Width > 0 && Height > 0;
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PixelSize.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PixelSize.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3baa5ba72b60e1e45acc62376bfb1576

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareConversionMode.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 45b9ef22902c02640bd883a06fb13ce4

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
@@ -9,9 +9,13 @@ namespace Sunmax0731.SquareCropEditor.Models
         public const string DefaultOutputFolder = "Assets/Generated/SquareCrop";
         public const string DefaultFileNameSuffix = "_crop";
 
+        public AspectRatioSpec CropAspectRatio { get; set; } = AspectRatioSpec.Square;
+
+        public AspectRatioSpec OutputAspectRatio { get; set; } = AspectRatioSpec.Square;
+
         public int OutputSize { get; set; } = DefaultOutputSize;
 
-        public SquareConversionMode ConversionMode { get; set; } = SquareConversionMode.Fit;
+        public CanvasMappingMode MappingMode { get; set; } = CanvasMappingMode.Fit;
 
         public string OutputFolder { get; set; } = DefaultOutputFolder;
 

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs
@@ -1,0 +1,111 @@
+using System;
+using Sunmax0731.SquareCropEditor.Models;
+
+namespace Sunmax0731.SquareCropEditor.Services
+{
+    public static class AspectOutputPlanner
+    {
+        public static PixelSize CalculateOutputSize(int longEdge, AspectRatioSpec aspectRatio)
+        {
+            if (longEdge <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(longEdge), "Output long edge must be positive.");
+            }
+
+            if (!aspectRatio.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(aspectRatio), "Aspect ratio must be positive.");
+            }
+
+            if (aspectRatio.Width >= aspectRatio.Height)
+            {
+                return new PixelSize(longEdge, Math.Max(1, (int)Math.Round((double)longEdge * aspectRatio.Height / aspectRatio.Width)));
+            }
+
+            return new PixelSize(Math.Max(1, (int)Math.Round((double)longEdge * aspectRatio.Width / aspectRatio.Height)), longEdge);
+        }
+
+        public static OutputMappingPlan Plan(CropSelection selection, int outputLongEdge, AspectRatioSpec outputAspectRatio, CanvasMappingMode mappingMode)
+        {
+            if (!selection.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(selection), "Selection must be positive.");
+            }
+
+            var outputSize = CalculateOutputSize(outputLongEdge, outputAspectRatio);
+            return Plan(selection, outputSize, mappingMode);
+        }
+
+        public static OutputMappingPlan Plan(CropSelection selection, PixelSize outputSize, CanvasMappingMode mappingMode)
+        {
+            if (!selection.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(selection), "Selection must be positive.");
+            }
+
+            if (!outputSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(outputSize), "Output size must be positive.");
+            }
+
+            switch (mappingMode)
+            {
+                case CanvasMappingMode.Fit:
+                    return PlanFit(selection, outputSize);
+                case CanvasMappingMode.Fill:
+                    return PlanFill(selection, outputSize);
+                case CanvasMappingMode.Stretch:
+                    return new OutputMappingPlan(
+                        outputSize,
+                        selection,
+                        new CropSelection(0, 0, outputSize.Width, outputSize.Height),
+                        CanvasMappingMode.Stretch);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mappingMode), mappingMode, "Unsupported mapping mode.");
+            }
+        }
+
+        private static OutputMappingPlan PlanFit(CropSelection selection, PixelSize outputSize)
+        {
+            var scale = Math.Min((double)outputSize.Width / selection.Width, (double)outputSize.Height / selection.Height);
+            var destinationWidth = Math.Max(1, (int)Math.Round(selection.Width * scale));
+            var destinationHeight = Math.Max(1, (int)Math.Round(selection.Height * scale));
+            var destinationX = (outputSize.Width - destinationWidth) / 2;
+            var destinationY = (outputSize.Height - destinationHeight) / 2;
+
+            return new OutputMappingPlan(
+                outputSize,
+                selection,
+                new CropSelection(destinationX, destinationY, destinationWidth, destinationHeight),
+                CanvasMappingMode.Fit);
+        }
+
+        private static OutputMappingPlan PlanFill(CropSelection selection, PixelSize outputSize)
+        {
+            var outputRatio = (double)outputSize.Width / outputSize.Height;
+            var sourceRatio = (double)selection.Width / selection.Height;
+
+            var sourceX = selection.X;
+            var sourceY = selection.Y;
+            var sourceWidth = selection.Width;
+            var sourceHeight = selection.Height;
+
+            if (sourceRatio > outputRatio)
+            {
+                sourceWidth = Math.Max(1, (int)Math.Round(selection.Height * outputRatio));
+                sourceX = selection.X + (selection.Width - sourceWidth) / 2;
+            }
+            else if (sourceRatio < outputRatio)
+            {
+                sourceHeight = Math.Max(1, (int)Math.Round(selection.Width / outputRatio));
+                sourceY = selection.Y + (selection.Height - sourceHeight) / 2;
+            }
+
+            return new OutputMappingPlan(
+                outputSize,
+                new CropSelection(sourceX, sourceY, sourceWidth, sourceHeight),
+                new CropSelection(0, 0, outputSize.Width, outputSize.Height),
+                CanvasMappingMode.Fill);
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b48a25904e6125f45ab0fe26e8bcac21

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
@@ -1,0 +1,132 @@
+using System;
+using Sunmax0731.SquareCropEditor.Models;
+
+namespace Sunmax0731.SquareCropEditor.Services
+{
+    public static class CropRectCalculator
+    {
+        public static CropSelection FromPreviewDrag(
+            double startX,
+            double startY,
+            double endX,
+            double endY,
+            PixelSize previewSize,
+            PixelSize sourceSize,
+            AspectRatioSpec aspectRatio)
+        {
+            if (!previewSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(previewSize), "Preview size must be positive.");
+            }
+
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            if (!aspectRatio.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(aspectRatio), "Aspect ratio must be positive.");
+            }
+
+            var sourceStartX = Clamp(startX * sourceSize.Width / previewSize.Width, 0, sourceSize.Width);
+            var sourceStartY = Clamp(startY * sourceSize.Height / previewSize.Height, 0, sourceSize.Height);
+            var sourceEndX = Clamp(endX * sourceSize.Width / previewSize.Width, 0, sourceSize.Width);
+            var sourceEndY = Clamp(endY * sourceSize.Height / previewSize.Height, 0, sourceSize.Height);
+
+            var directionX = sourceEndX >= sourceStartX ? 1 : -1;
+            var directionY = sourceEndY >= sourceStartY ? 1 : -1;
+            var requestedWidth = Math.Abs(sourceEndX - sourceStartX);
+            var requestedHeight = Math.Abs(sourceEndY - sourceStartY);
+
+            if (requestedWidth <= 0 && requestedHeight <= 0)
+            {
+                return new CropSelection((int)Math.Round(sourceStartX), (int)Math.Round(sourceStartY), 0, 0);
+            }
+
+            var maxWidth = directionX > 0 ? sourceSize.Width - sourceStartX : sourceStartX;
+            var maxHeight = directionY > 0 ? sourceSize.Height - sourceStartY : sourceStartY;
+            requestedWidth = Math.Min(requestedWidth, maxWidth);
+            requestedHeight = Math.Min(requestedHeight, maxHeight);
+
+            var ratio = aspectRatio.Value;
+            var width = requestedWidth;
+            var height = requestedHeight;
+
+            if (width <= 0)
+            {
+                width = height * ratio;
+            }
+            else if (height <= 0)
+            {
+                height = width / ratio;
+            }
+            else if (width / height > ratio)
+            {
+                width = height * ratio;
+            }
+            else
+            {
+                height = width / ratio;
+            }
+
+            if (width > maxWidth)
+            {
+                width = maxWidth;
+                height = width / ratio;
+            }
+
+            if (height > maxHeight)
+            {
+                height = maxHeight;
+                width = height * ratio;
+            }
+
+            var x = directionX > 0 ? sourceStartX : sourceStartX - width;
+            var y = directionY > 0 ? sourceStartY : sourceStartY - height;
+
+            return RoundSelection(x, y, width, height, sourceSize, aspectRatio);
+        }
+
+        private static CropSelection RoundSelection(double x, double y, double width, double height, PixelSize sourceSize, AspectRatioSpec aspectRatio)
+        {
+            var roundedWidth = Math.Max(1, (int)Math.Round(width));
+            var roundedHeight = Math.Max(1, (int)Math.Round(roundedWidth / aspectRatio.Value));
+
+            if (roundedHeight < 1)
+            {
+                roundedHeight = 1;
+            }
+
+            if (roundedHeight > sourceSize.Height)
+            {
+                roundedHeight = sourceSize.Height;
+                roundedWidth = Math.Max(1, (int)Math.Round(roundedHeight * aspectRatio.Value));
+            }
+
+            if (roundedWidth > sourceSize.Width)
+            {
+                roundedWidth = sourceSize.Width;
+                roundedHeight = Math.Max(1, (int)Math.Round(roundedWidth / aspectRatio.Value));
+            }
+
+            var roundedX = (int)Math.Round(x);
+            var roundedY = (int)Math.Round(y);
+
+            roundedX = Math.Max(0, Math.Min(roundedX, sourceSize.Width - roundedWidth));
+            roundedY = Math.Max(0, Math.Min(roundedY, sourceSize.Height - roundedHeight));
+
+            return new CropSelection(roundedX, roundedY, roundedWidth, roundedHeight);
+        }
+
+        private static double Clamp(double value, double min, double max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            return value > max ? max : value;
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de2c631910a55ed4da76e2ba3c75085e

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+using Sunmax0731.SquareCropEditor.Models;
+using Sunmax0731.SquareCropEditor.Services;
+
+namespace Sunmax0731.SquareCropEditor.Tests.Editor
+{
+    public sealed class AspectMappingTests
+    {
+        [Test]
+        public void OutputSizeUsesLongEdgeForLandscapeRatio()
+        {
+            var size = AspectOutputPlanner.CalculateOutputSize(256, AspectRatioSpec.Landscape16By9);
+
+            Assert.That(size.Width, Is.EqualTo(256));
+            Assert.That(size.Height, Is.EqualTo(144));
+        }
+
+        [Test]
+        public void OutputSizeUsesLongEdgeForPortraitRatio()
+        {
+            var size = AspectOutputPlanner.CalculateOutputSize(256, AspectRatioSpec.Portrait9By16);
+
+            Assert.That(size.Width, Is.EqualTo(144));
+            Assert.That(size.Height, Is.EqualTo(256));
+        }
+
+        [Test]
+        public void CropDragConstrainsToSquareRatio()
+        {
+            var selection = CropRectCalculator.FromPreviewDrag(
+                10,
+                10,
+                90,
+                50,
+                new PixelSize(100, 100),
+                new PixelSize(200, 200),
+                AspectRatioSpec.Square);
+
+            Assert.That(selection.X, Is.EqualTo(20));
+            Assert.That(selection.Y, Is.EqualTo(20));
+            Assert.That(selection.Width, Is.EqualTo(80));
+            Assert.That(selection.Height, Is.EqualTo(80));
+        }
+
+        [Test]
+        public void CropDragPreservesDirectionAndClampsToBounds()
+        {
+            var selection = CropRectCalculator.FromPreviewDrag(
+                95,
+                95,
+                30,
+                10,
+                new PixelSize(100, 100),
+                new PixelSize(100, 100),
+                AspectRatioSpec.Landscape4By3);
+
+            Assert.That(selection.X, Is.EqualTo(30));
+            Assert.That(selection.Y, Is.EqualTo(46));
+            Assert.That(selection.Width, Is.EqualTo(65));
+            Assert.That(selection.Height, Is.EqualTo(49));
+        }
+
+        [Test]
+        public void FitMapsFullSourceInsideTransparentCanvasArea()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(0, 0, 200, 100),
+                new PixelSize(256, 256),
+                CanvasMappingMode.Fit);
+
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(0, 0, 200, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(0, 64, 256, 128)));
+        }
+
+        [Test]
+        public void FillCropsSourceToOutputRatio()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(0, 0, 200, 100),
+                new PixelSize(256, 256),
+                CanvasMappingMode.Fill);
+
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(50, 0, 100, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(0, 0, 256, 256)));
+        }
+
+        [Test]
+        public void StretchUsesFullSourceAndFullCanvas()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(10, 20, 200, 100),
+                new PixelSize(256, 144),
+                CanvasMappingMode.Stretch);
+
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(10, 20, 200, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(0, 0, 256, 144)));
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a80502f9bfe7374eb570457647d6c21

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/SquareCropPackageScaffoldTests.cs
@@ -13,8 +13,10 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
 
             Assert.That(SquareCropDefaults.MenuPath, Is.EqualTo("Tools/Square Crop Editor/Open"));
             Assert.That(settings.OutputSize, Is.EqualTo(256));
+            Assert.That(settings.CropAspectRatio, Is.EqualTo(AspectRatioSpec.Square));
+            Assert.That(settings.OutputAspectRatio, Is.EqualTo(AspectRatioSpec.Square));
             Assert.That(settings.OutputFolder, Is.EqualTo("Assets/Generated/SquareCrop"));
-            Assert.That(settings.ConversionMode, Is.EqualTo(SquareConversionMode.Fit));
+            Assert.That(settings.MappingMode, Is.EqualTo(CanvasMappingMode.Fit));
             Assert.That(settings.ConflictBehavior, Is.EqualTo(ExportConflictBehavior.Duplicate));
         }
 


### PR DESCRIPTION
## 概要
- `AspectRatioSpec` / `PixelSize` / `OutputMappingPlan` を追加
- `SquareConversionMode` を `CanvasMappingMode` に整理
- crop selection 用の `CropRectCalculator` を追加
- output long edge と aspect ratio から canvas dimensions を計算する `AspectOutputPlanner` を追加
- `Fit` / `Fill` / `Stretch` の mapping plan を実装
- aspect mapping の EditMode tests を追加

## 検証
- Unity `6000.4.0f1` 一時 project で package import / script compilation 成功
- `Library/ScriptAssemblies` に Runtime / Editor / Editor.Tests DLL 生成を確認
- `dotnet run` の一時 console check で主要 pure logic cases が `PURE_LOGIC_CHECK=PASS`
- 注意: Unity `-runTests` は exit code 0 で終了したが `-testResults` XML を出力しなかったため、CLI test runner の結果 XML は未取得

Closes #4