### PR TITLE
feat: PNG export service を追加

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs
@@ -1,0 +1,25 @@
+using System;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public sealed class PngExportRequest
+    {
+        public Texture2D SourceTexture { get; set; }
+
+        public CropSelection Selection { get; set; }
+
+        public int OutputLongEdge { get; set; } = SquareCropSettings.DefaultOutputSize;
+
+        public AspectRatioSpec OutputAspectRatio { get; set; } = AspectRatioSpec.Square;
+
+        public CanvasMappingMode MappingMode { get; set; } = CanvasMappingMode.Fit;
+
+        public string OutputFolder { get; set; } = SquareCropSettings.DefaultOutputFolder;
+
+        public string OutputFileName { get; set; } = string.Empty;
+
+        public ExportConflictBehavior ConflictBehavior { get; set; } = ExportConflictBehavior.Duplicate;
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1bbb22161b80bb4aa26b66f8a88ba94

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportResult.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportResult.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    [Serializable]
+    public readonly struct PngExportResult
+    {
+        public PngExportResult(PngExportStatus status, string outputPath, PixelSize outputSize, string message)
+        {
+            Status = status;
+            OutputPath = outputPath;
+            OutputSize = outputSize;
+            Message = message;
+        }
+
+        public PngExportStatus Status { get; }
+
+        public string OutputPath { get; }
+
+        public PixelSize OutputSize { get; }
+
+        public string Message { get; }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportResult.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 31578b856b664a14fb7853939232d8c3

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportStatus.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportStatus.cs
@@ -1,0 +1,9 @@
+namespace Sunmax0731.SquareCropEditor.Models
+{
+    public enum PngExportStatus
+    {
+        Exported = 0,
+        Skipped = 1,
+        Error = 2
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportStatus.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportStatus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 38a2c2d64f6aa2341ba8e8ecd9ac0e08

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using Sunmax0731.SquareCropEditor.Models;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Services
+{
+    public static class PngAspectExporter
+    {
+        public static PngExportResult Export(PngExportRequest request)
+        {
+            var validationError = Validate(request);
+            if (!string.IsNullOrEmpty(validationError))
+            {
+                return new PngExportResult(PngExportStatus.Error, string.Empty, default, validationError);
+            }
+
+            var outputSize = AspectOutputPlanner.CalculateOutputSize(request.OutputLongEdge, request.OutputAspectRatio);
+            var outputPath = ResolveOutputPath(request.OutputFolder, request.OutputFileName);
+            var conflictPath = ResolveConflict(outputPath, request.ConflictBehavior);
+
+            if (string.IsNullOrEmpty(conflictPath))
+            {
+                return new PngExportResult(PngExportStatus.Skipped, outputPath, outputSize, "Output file already exists.");
+            }
+
+            try
+            {
+                var plan = AspectOutputPlanner.Plan(request.Selection, outputSize, request.MappingMode);
+                var outputTexture = Render(request.SourceTexture, plan);
+                var pngBytes = ImageConversion.EncodeToPNG(outputTexture);
+                UnityEngine.Object.DestroyImmediate(outputTexture);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(conflictPath));
+                File.WriteAllBytes(conflictPath, pngBytes);
+
+                return new PngExportResult(PngExportStatus.Exported, conflictPath, outputSize, "Exported.");
+            }
+            catch (Exception ex)
+            {
+                return new PngExportResult(PngExportStatus.Error, conflictPath, outputSize, ex.Message);
+            }
+        }
+
+        public static Texture2D Render(Texture2D sourceTexture, OutputMappingPlan plan)
+        {
+            if (sourceTexture == null)
+            {
+                throw new ArgumentNullException(nameof(sourceTexture));
+            }
+
+            if (!plan.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(plan), "Mapping plan must be valid.");
+            }
+
+            var output = new Texture2D(plan.OutputSize.Width, plan.OutputSize.Height, TextureFormat.RGBA32, false);
+            var clearPixels = new Color32[plan.OutputSize.Width * plan.OutputSize.Height];
+            for (var i = 0; i < clearPixels.Length; i++)
+            {
+                clearPixels[i] = new Color32(0, 0, 0, 0);
+            }
+
+            output.SetPixels32(clearPixels);
+
+            for (var destY = 0; destY < plan.DestinationRect.Height; destY++)
+            {
+                for (var destX = 0; destX < plan.DestinationRect.Width; destX++)
+                {
+                    var sourceX = plan.SourceRect.X + Math.Min(
+                        plan.SourceRect.Width - 1,
+                        (int)Math.Floor((destX + 0.5d) * plan.SourceRect.Width / plan.DestinationRect.Width));
+                    var sourceTopY = plan.SourceRect.Y + Math.Min(
+                        plan.SourceRect.Height - 1,
+                        (int)Math.Floor((destY + 0.5d) * plan.SourceRect.Height / plan.DestinationRect.Height));
+
+                    var outputX = plan.DestinationRect.X + destX;
+                    var outputTopY = plan.DestinationRect.Y + destY;
+
+                    var sourceBottomY = sourceTexture.height - 1 - sourceTopY;
+                    var outputBottomY = plan.OutputSize.Height - 1 - outputTopY;
+                    output.SetPixel(outputX, outputBottomY, sourceTexture.GetPixel(sourceX, sourceBottomY));
+                }
+            }
+
+            output.Apply(false, false);
+            return output;
+        }
+
+        private static string Validate(PngExportRequest request)
+        {
+            if (request == null)
+            {
+                return "Export request is missing.";
+            }
+
+            if (request.SourceTexture == null)
+            {
+                return "Source texture is missing.";
+            }
+
+            if (!request.Selection.IsValid)
+            {
+                return "Crop selection is invalid.";
+            }
+
+            if (request.OutputLongEdge <= 0)
+            {
+                return "Output size must be positive.";
+            }
+
+            if (!request.OutputAspectRatio.IsValid)
+            {
+                return "Output aspect ratio is invalid.";
+            }
+
+            if (string.IsNullOrWhiteSpace(request.OutputFolder))
+            {
+                return "Output folder is missing.";
+            }
+
+            if (string.IsNullOrWhiteSpace(request.OutputFileName))
+            {
+                return "Output file name is missing.";
+            }
+
+            if (request.OutputFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return "Output file name contains invalid characters.";
+            }
+
+            return string.Empty;
+        }
+
+        private static string ResolveOutputPath(string outputFolder, string outputFileName)
+        {
+            var fileName = Path.GetExtension(outputFileName).Equals(".png", StringComparison.OrdinalIgnoreCase)
+                ? outputFileName
+                : outputFileName + ".png";
+            return Path.GetFullPath(Path.Combine(outputFolder, fileName));
+        }
+
+        private static string ResolveConflict(string outputPath, ExportConflictBehavior conflictBehavior)
+        {
+            if (!File.Exists(outputPath) || conflictBehavior == ExportConflictBehavior.Overwrite)
+            {
+                return outputPath;
+            }
+
+            if (conflictBehavior == ExportConflictBehavior.Skip)
+            {
+                return string.Empty;
+            }
+
+            var directory = Path.GetDirectoryName(outputPath);
+            var fileName = Path.GetFileNameWithoutExtension(outputPath);
+            var extension = Path.GetExtension(outputPath);
+
+            for (var index = 1; index <= 999; index++)
+            {
+                var candidate = Path.Combine(directory, $"{fileName}_copy{index:00}{extension}");
+                if (!File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new IOException("Could not resolve a duplicate output path.");
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5c74d512cb902f46b46c5e901b5855f

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
@@ -1,0 +1,211 @@
+using System.IO;
+using NUnit.Framework;
+using Sunmax0731.SquareCropEditor.Models;
+using Sunmax0731.SquareCropEditor.Services;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Tests.Editor
+{
+    public sealed class PngAspectExporterTests
+    {
+        private string _tempFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempFolder = Path.Combine(Path.GetTempPath(), "UnitySquareCropEditorTests", TestContext.CurrentContext.Test.ID);
+            if (Directory.Exists(_tempFolder))
+            {
+                Directory.Delete(_tempFolder, true);
+            }
+
+            Directory.CreateDirectory(_tempFolder);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_tempFolder))
+            {
+                Directory.Delete(_tempFolder, true);
+            }
+        }
+
+        [Test]
+        public void ExportCreatesPngWithRequestedAspectDimensions()
+        {
+            var source = CreateSourceTexture();
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = source,
+                Selection = new CropSelection(0, 0, 4, 4),
+                OutputLongEdge = 16,
+                OutputAspectRatio = AspectRatioSpec.Landscape16By9,
+                MappingMode = CanvasMappingMode.Stretch,
+                OutputFolder = _tempFolder,
+                OutputFileName = "landscape"
+            });
+
+            Assert.That(result.Status, Is.EqualTo(PngExportStatus.Exported));
+            Assert.That(File.Exists(result.OutputPath), Is.True);
+
+            var exported = LoadPng(result.OutputPath);
+            Assert.That(exported.width, Is.EqualTo(16));
+            Assert.That(exported.height, Is.EqualTo(9));
+
+            UnityEngine.Object.DestroyImmediate(source);
+            UnityEngine.Object.DestroyImmediate(exported);
+        }
+
+        [Test]
+        public void FitLeavesTransparentPadding()
+        {
+            var source = CreateSourceTexture();
+            var output = PngAspectExporter.Render(
+                source,
+                AspectOutputPlanner.Plan(new CropSelection(0, 0, 4, 2), new PixelSize(8, 8), CanvasMappingMode.Fit));
+
+            Assert.That(output.GetPixel(0, 0).a, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(output.GetPixel(4, 4).a, Is.GreaterThan(0f));
+
+            UnityEngine.Object.DestroyImmediate(source);
+            UnityEngine.Object.DestroyImmediate(output);
+        }
+
+        [Test]
+        public void ExportPreservesSourceAlpha()
+        {
+            var source = CreateSourceTexture();
+            var output = PngAspectExporter.Render(
+                source,
+                AspectOutputPlanner.Plan(new CropSelection(0, 0, 4, 4), new PixelSize(4, 4), CanvasMappingMode.Stretch));
+
+            Assert.That(output.GetPixel(0, 0).a, Is.EqualTo(1f / 7f).Within(0.01f));
+            Assert.That(output.GetPixel(3, 3).a, Is.EqualTo(1f).Within(0.01f));
+
+            UnityEngine.Object.DestroyImmediate(source);
+            UnityEngine.Object.DestroyImmediate(output);
+        }
+
+        [Test]
+        public void SkipConflictDoesNotOverwriteExistingFile()
+        {
+            var existingPath = Path.Combine(_tempFolder, "icon.png");
+            File.WriteAllText(existingPath, "existing");
+
+            var source = CreateSourceTexture();
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = source,
+                Selection = new CropSelection(0, 0, 4, 4),
+                OutputLongEdge = 4,
+                OutputAspectRatio = AspectRatioSpec.Square,
+                MappingMode = CanvasMappingMode.Stretch,
+                OutputFolder = _tempFolder,
+                OutputFileName = "icon.png",
+                ConflictBehavior = ExportConflictBehavior.Skip
+            });
+
+            Assert.That(result.Status, Is.EqualTo(PngExportStatus.Skipped));
+            Assert.That(File.ReadAllText(existingPath), Is.EqualTo("existing"));
+
+            UnityEngine.Object.DestroyImmediate(source);
+        }
+
+        [Test]
+        public void DuplicateConflictCreatesStableCopySuffix()
+        {
+            File.WriteAllText(Path.Combine(_tempFolder, "icon.png"), "existing");
+
+            var source = CreateSourceTexture();
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = source,
+                Selection = new CropSelection(0, 0, 4, 4),
+                OutputLongEdge = 4,
+                OutputAspectRatio = AspectRatioSpec.Square,
+                MappingMode = CanvasMappingMode.Stretch,
+                OutputFolder = _tempFolder,
+                OutputFileName = "icon.png",
+                ConflictBehavior = ExportConflictBehavior.Duplicate
+            });
+
+            Assert.That(result.Status, Is.EqualTo(PngExportStatus.Exported));
+            Assert.That(Path.GetFileName(result.OutputPath), Is.EqualTo("icon_copy01.png"));
+            Assert.That(File.Exists(result.OutputPath), Is.True);
+
+            UnityEngine.Object.DestroyImmediate(source);
+        }
+
+        [Test]
+        public void OverwriteConflictReplacesExistingFile()
+        {
+            var existingPath = Path.Combine(_tempFolder, "icon.png");
+            File.WriteAllText(existingPath, "existing");
+
+            var source = CreateSourceTexture();
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = source,
+                Selection = new CropSelection(0, 0, 4, 4),
+                OutputLongEdge = 4,
+                OutputAspectRatio = AspectRatioSpec.Square,
+                MappingMode = CanvasMappingMode.Stretch,
+                OutputFolder = _tempFolder,
+                OutputFileName = "icon.png",
+                ConflictBehavior = ExportConflictBehavior.Overwrite
+            });
+
+            Assert.That(result.Status, Is.EqualTo(PngExportStatus.Exported));
+            Assert.That(result.OutputPath, Is.EqualTo(Path.GetFullPath(existingPath)));
+            Assert.That(File.ReadAllText(existingPath), Is.Not.EqualTo("existing"));
+
+            UnityEngine.Object.DestroyImmediate(source);
+        }
+
+        [Test]
+        public void InvalidRequestRecordsErrorStatus()
+        {
+            var source = CreateSourceTexture();
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = source,
+                Selection = new CropSelection(0, 0, 4, 4),
+                OutputLongEdge = 4,
+                OutputAspectRatio = AspectRatioSpec.Square,
+                MappingMode = CanvasMappingMode.Stretch,
+                OutputFolder = _tempFolder,
+                OutputFileName = string.Empty
+            });
+
+            Assert.That(result.Status, Is.EqualTo(PngExportStatus.Error));
+            Assert.That(result.Message, Is.EqualTo("Output file name is missing."));
+
+            UnityEngine.Object.DestroyImmediate(source);
+        }
+
+        private static Texture2D CreateSourceTexture()
+        {
+            var texture = new Texture2D(4, 4, TextureFormat.RGBA32, false);
+            var pixels = new Color[16];
+            for (var y = 0; y < 4; y++)
+            {
+                for (var x = 0; x < 4; x++)
+                {
+                    pixels[y * 4 + x] = new Color(x / 3f, y / 3f, 1f, (x + y + 1) / 7f);
+                }
+            }
+
+            texture.SetPixels(pixels);
+            texture.Apply();
+            return texture;
+        }
+
+        private static Texture2D LoadPng(string path)
+        {
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            ImageConversion.LoadImage(texture, File.ReadAllBytes(path));
+            return texture;
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca750533a2dfb7f42b8df1305ca4bce3

--- a/Packages/com.sunmax0731.square-crop-editor/package.json
+++ b/Packages/com.sunmax0731.square-crop-editor/package.json
@@ -3,7 +3,7 @@
   "displayName": "Unity Square Crop Editor",
   "version": "0.1.0",
   "unity": "6000.0",
-  "description": "Unity Editor extension for drag-selecting an image region and exporting it as a square PNG.",
+  "description": "Unity Editor extension for drag-selecting a transparent image region and exporting it as an aspect-ratio PNG.",
   "keywords": [
     "editor",
     "texture",
@@ -11,6 +11,9 @@
     "png",
     "square"
   ],
+  "dependencies": {
+    "com.unity.modules.imageconversion": "1.0.0"
+  },
   "author": {
     "name": "Sunmax0731",
     "url": "https://github.com/Sunmax0731"


### PR DESCRIPTION
## 概要
- `PngAspectExporter` を追加し、選択範囲を指定aspect ratio / long edge sizeのPNGとして書き出し
- `Fit` / `Fill` / `Stretch` の mapping plan に従ってresampling
- source alpha preservation と `Fit` transparent padding を実装
- overwrite / skip / duplicate conflict behavior を実装
- `com.unity.modules.imageconversion` dependency を追加
- PNG export result / request / status model と EditMode tests を追加

## 検証
- Unity `6000.4.0f1` 一時 project で package import / script compilation 成功
- `-executeMethod Issue5ExportSmoke.Run` で `ISSUE5_EXPORT_SMOKE=PASS`
- smoke でPNG書き出し、16:9 dimensions読み戻し、Fit padding透明を確認
- 注意: Unity `-runTests` は exit code 0 で終了したが `-testResults` XML を出力しなかったため、CLI test runner の結果 XML は未取得

Closes #5