### PR TITLE
feat: Editor Window MVP を実装

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using Sunmax0731.SquareCropEditor.Models;
 using Sunmax0731.SquareCropEditor.Services;
 using UnityEditor;
 using UnityEngine;
@@ -8,6 +11,26 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
     {
         public const string WindowTitle = "Square Crop Editor";
 
+        private const int MinPreviewHeight = 280;
+        private static readonly Color SelectionColor = new Color(0.2f, 0.65f, 1f, 0.95f);
+        private static readonly Color SelectionFillColor = new Color(0.2f, 0.65f, 1f, 0.16f);
+
+        private Texture2D _sourceTexture;
+        private Texture2D _outputPreview;
+        private Texture2D _checkerboard;
+        private CropSelection _selection;
+        private SquareCropSettings _settings;
+        private AspectPreset _cropPreset = AspectPreset.Square;
+        private AspectPreset _outputPreset = AspectPreset.Square;
+        private int _customCropWidth = 1;
+        private int _customCropHeight = 1;
+        private int _customOutputWidth = 1;
+        private int _customOutputHeight = 1;
+        private Vector2 _dragStart;
+        private bool _isDragging;
+        private string _statusMessage = "Select a source texture.";
+        private MessageType _statusType = MessageType.Info;
+
         [MenuItem(SquareCropDefaults.MenuPath)]
         public static void Open()
         {
@@ -16,10 +39,372 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             window.Show();
         }
 
+        private void OnEnable()
+        {
+            _settings = SquareCropDefaults.CreateSettings();
+            if (string.IsNullOrEmpty(_settings.OutputFileName))
+            {
+                _settings.OutputFileName = "square_crop.png";
+            }
+
+            _checkerboard = CreateCheckerboardTexture();
+        }
+
+        private void OnDisable()
+        {
+            DestroyPreviewTexture();
+            if (_checkerboard != null)
+            {
+                DestroyImmediate(_checkerboard);
+                _checkerboard = null;
+            }
+        }
+
         private void OnGUI()
         {
+            _settings ??= SquareCropDefaults.CreateSettings();
+
             EditorGUILayout.LabelField(WindowTitle, EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Package scaffold is ready. Crop UI implementation starts from the next issues.", MessageType.Info);
+            EditorGUILayout.HelpBox(_statusMessage, _statusType);
+
+            using (var change = new EditorGUI.ChangeCheckScope())
+            {
+                DrawSourceControls();
+                DrawAspectControls();
+                DrawOutputControls();
+
+                if (change.changed)
+                {
+                    RefreshOutputPreview();
+                }
+            }
+
+            DrawPreviewArea();
+            DrawExportButton();
+        }
+
+        private void DrawSourceControls()
+        {
+            EditorGUILayout.Space(4);
+            var texture = (Texture2D)EditorGUILayout.ObjectField("Source Image", _sourceTexture, typeof(Texture2D), false);
+            if (texture != _sourceTexture)
+            {
+                _sourceTexture = texture;
+                _selection = default;
+                DestroyPreviewTexture();
+                if (_sourceTexture != null)
+                {
+                    _settings.OutputFileName = Path.GetFileNameWithoutExtension(AssetDatabase.GetAssetPath(_sourceTexture)) + SquareCropSettings.DefaultFileNameSuffix + ".png";
+                    SetStatus($"Source: {_sourceTexture.width} x {_sourceTexture.height}", MessageType.Info);
+                }
+                else
+                {
+                    SetStatus("Select a source texture.", MessageType.Info);
+                }
+            }
+        }
+
+        private void DrawAspectControls()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                _cropPreset = (AspectPreset)EditorGUILayout.EnumPopup("Crop Ratio", _cropPreset);
+                if (_cropPreset == AspectPreset.Custom)
+                {
+                    _customCropWidth = Mathf.Max(1, EditorGUILayout.IntField(_customCropWidth, GUILayout.Width(48)));
+                    EditorGUILayout.LabelField(":", GUILayout.Width(8));
+                    _customCropHeight = Mathf.Max(1, EditorGUILayout.IntField(_customCropHeight, GUILayout.Width(48)));
+                }
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                _outputPreset = (AspectPreset)EditorGUILayout.EnumPopup("Output Ratio", _outputPreset);
+                if (_outputPreset == AspectPreset.Custom)
+                {
+                    _customOutputWidth = Mathf.Max(1, EditorGUILayout.IntField(_customOutputWidth, GUILayout.Width(48)));
+                    EditorGUILayout.LabelField(":", GUILayout.Width(8));
+                    _customOutputHeight = Mathf.Max(1, EditorGUILayout.IntField(_customOutputHeight, GUILayout.Width(48)));
+                }
+            }
+        }
+
+        private void DrawOutputControls()
+        {
+            _settings.OutputSize = Mathf.Max(1, EditorGUILayout.IntField("Output Long Edge", _settings.OutputSize));
+            _settings.MappingMode = (CanvasMappingMode)EditorGUILayout.EnumPopup("Mapping", _settings.MappingMode);
+            _settings.ConflictBehavior = (ExportConflictBehavior)EditorGUILayout.EnumPopup("Conflict", _settings.ConflictBehavior);
+            _settings.OutputFolder = EditorGUILayout.TextField("Output Folder", _settings.OutputFolder);
+            _settings.OutputFileName = EditorGUILayout.TextField("Output File", _settings.OutputFileName);
+        }
+
+        private void DrawPreviewArea()
+        {
+            EditorGUILayout.Space(8);
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                DrawSourcePreview();
+                DrawOutputPreview();
+            }
+        }
+
+        private void DrawSourcePreview()
+        {
+            using (new EditorGUILayout.VerticalScope(GUILayout.MinWidth(position.width * 0.58f)))
+            {
+                EditorGUILayout.LabelField("Source", EditorStyles.boldLabel);
+                var previewRect = GUILayoutUtility.GetRect(10, 10000, MinPreviewHeight, MinPreviewHeight, GUILayout.ExpandWidth(true));
+                EditorGUI.DrawRect(previewRect, new Color(0.13f, 0.13f, 0.13f));
+
+                if (_sourceTexture == null)
+                {
+                    DrawCenteredLabel(previewRect, "No source image");
+                    return;
+                }
+
+                var imageRect = FitRect(previewRect, _sourceTexture.width, _sourceTexture.height);
+                GUI.DrawTexture(imageRect, _sourceTexture, ScaleMode.StretchToFill, true);
+                HandleDragSelection(imageRect);
+                DrawSelection(imageRect);
+            }
+        }
+
+        private void DrawOutputPreview()
+        {
+            using (new EditorGUILayout.VerticalScope(GUILayout.Width(Mathf.Max(260, position.width * 0.32f))))
+            {
+                EditorGUILayout.LabelField("Output", EditorStyles.boldLabel);
+                var previewRect = GUILayoutUtility.GetRect(240, MinPreviewHeight, GUILayout.ExpandWidth(true));
+                EditorGUI.DrawRect(previewRect, new Color(0.13f, 0.13f, 0.13f));
+
+                if (_outputPreview == null)
+                {
+                    DrawCenteredLabel(previewRect, "No preview");
+                    return;
+                }
+
+                var imageRect = FitRect(previewRect, _outputPreview.width, _outputPreview.height);
+                GUI.DrawTextureWithTexCoords(imageRect, _checkerboard, new Rect(0, 0, imageRect.width / _checkerboard.width, imageRect.height / _checkerboard.height));
+                GUI.DrawTexture(imageRect, _outputPreview, ScaleMode.StretchToFill, true);
+                EditorGUILayout.LabelField($"{_outputPreview.width} x {_outputPreview.height}");
+            }
+        }
+
+        private void DrawExportButton()
+        {
+            using (new EditorGUI.DisabledScope(_sourceTexture == null || !_selection.IsValid))
+            {
+                if (GUILayout.Button("Export PNG", GUILayout.Height(28)))
+                {
+                    ExportPng();
+                }
+            }
+        }
+
+        private void HandleDragSelection(Rect imageRect)
+        {
+            var currentEvent = Event.current;
+            if (currentEvent == null)
+            {
+                return;
+            }
+
+            if (currentEvent.type == EventType.MouseDown && currentEvent.button == 0 && imageRect.Contains(currentEvent.mousePosition))
+            {
+                _dragStart = currentEvent.mousePosition;
+                _isDragging = true;
+                currentEvent.Use();
+            }
+
+            if (_isDragging && (currentEvent.type == EventType.MouseDrag || currentEvent.type == EventType.MouseUp))
+            {
+                var localStart = _dragStart - imageRect.position;
+                var localEnd = currentEvent.mousePosition - imageRect.position;
+                _selection = CropRectCalculator.FromPreviewDrag(
+                    localStart.x,
+                    localStart.y,
+                    localEnd.x,
+                    localEnd.y,
+                    new PixelSize(Mathf.RoundToInt(imageRect.width), Mathf.RoundToInt(imageRect.height)),
+                    new PixelSize(_sourceTexture.width, _sourceTexture.height),
+                    GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                RefreshOutputPreview();
+                Repaint();
+                currentEvent.Use();
+
+                if (currentEvent.type == EventType.MouseUp)
+                {
+                    _isDragging = false;
+                }
+            }
+        }
+
+        private void DrawSelection(Rect imageRect)
+        {
+            if (!_selection.IsValid || _sourceTexture == null)
+            {
+                return;
+            }
+
+            var x = imageRect.x + imageRect.width * _selection.X / _sourceTexture.width;
+            var y = imageRect.y + imageRect.height * _selection.Y / _sourceTexture.height;
+            var width = imageRect.width * _selection.Width / _sourceTexture.width;
+            var height = imageRect.height * _selection.Height / _sourceTexture.height;
+            var rect = new Rect(x, y, width, height);
+
+            EditorGUI.DrawRect(rect, SelectionFillColor);
+            Handles.BeginGUI();
+            Handles.color = SelectionColor;
+            Handles.DrawAAPolyLine(3f, new Vector3(rect.xMin, rect.yMin), new Vector3(rect.xMax, rect.yMin), new Vector3(rect.xMax, rect.yMax), new Vector3(rect.xMin, rect.yMax), new Vector3(rect.xMin, rect.yMin));
+            Handles.EndGUI();
+        }
+
+        private void RefreshOutputPreview()
+        {
+            DestroyPreviewTexture();
+
+            if (_sourceTexture == null || !_selection.IsValid)
+            {
+                return;
+            }
+
+            try
+            {
+                var outputSize = AspectOutputPlanner.CalculateOutputSize(_settings.OutputSize, GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight));
+                var plan = AspectOutputPlanner.Plan(_selection, outputSize, _settings.MappingMode);
+                _outputPreview = PngAspectExporter.Render(_sourceTexture, plan);
+                SetStatus($"Selection: {_selection.Width} x {_selection.Height}", MessageType.Info);
+            }
+            catch (Exception ex)
+            {
+                SetStatus(ex.Message, MessageType.Error);
+            }
+        }
+
+        private void ExportPng()
+        {
+            var result = PngAspectExporter.Export(new PngExportRequest
+            {
+                SourceTexture = _sourceTexture,
+                Selection = _selection,
+                OutputLongEdge = _settings.OutputSize,
+                OutputAspectRatio = GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight),
+                MappingMode = _settings.MappingMode,
+                OutputFolder = _settings.OutputFolder,
+                OutputFileName = _settings.OutputFileName,
+                ConflictBehavior = _settings.ConflictBehavior
+            });
+
+            if (result.Status == PngExportStatus.Exported)
+            {
+                RefreshAssetDatabaseIfNeeded(result.OutputPath);
+                SetStatus($"Exported: {result.OutputPath}", MessageType.Info);
+            }
+            else if (result.Status == PngExportStatus.Skipped)
+            {
+                SetStatus(result.Message, MessageType.Warning);
+            }
+            else
+            {
+                SetStatus(result.Message, MessageType.Error);
+            }
+        }
+
+        private static AspectRatioSpec GetAspectRatio(AspectPreset preset, int customWidth, int customHeight)
+        {
+            switch (preset)
+            {
+                case AspectPreset.Square:
+                    return AspectRatioSpec.Square;
+                case AspectPreset.Landscape4By3:
+                    return AspectRatioSpec.Landscape4By3;
+                case AspectPreset.Portrait3By4:
+                    return AspectRatioSpec.Portrait3By4;
+                case AspectPreset.Landscape16By9:
+                    return AspectRatioSpec.Landscape16By9;
+                case AspectPreset.Portrait9By16:
+                    return AspectRatioSpec.Portrait9By16;
+                case AspectPreset.Custom:
+                    return new AspectRatioSpec(Mathf.Max(1, customWidth), Mathf.Max(1, customHeight));
+                default:
+                    return AspectRatioSpec.Square;
+            }
+        }
+
+        private static Rect FitRect(Rect container, float width, float height)
+        {
+            var scale = Mathf.Min(container.width / width, container.height / height);
+            var fittedWidth = width * scale;
+            var fittedHeight = height * scale;
+            return new Rect(
+                container.x + (container.width - fittedWidth) * 0.5f,
+                container.y + (container.height - fittedHeight) * 0.5f,
+                fittedWidth,
+                fittedHeight);
+        }
+
+        private static void DrawCenteredLabel(Rect rect, string text)
+        {
+            var style = new GUIStyle(EditorStyles.centeredGreyMiniLabel)
+            {
+                alignment = TextAnchor.MiddleCenter
+            };
+            GUI.Label(rect, text, style);
+        }
+
+        private static Texture2D CreateCheckerboardTexture()
+        {
+            var texture = new Texture2D(16, 16, TextureFormat.RGBA32, false)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+                wrapMode = TextureWrapMode.Repeat,
+                filterMode = FilterMode.Point
+            };
+            for (var y = 0; y < texture.height; y++)
+            {
+                for (var x = 0; x < texture.width; x++)
+                {
+                    var light = ((x / 4) + (y / 4)) % 2 == 0;
+                    texture.SetPixel(x, y, light ? new Color(0.72f, 0.72f, 0.72f) : new Color(0.48f, 0.48f, 0.48f));
+                }
+            }
+
+            texture.Apply();
+            return texture;
+        }
+
+        private static void RefreshAssetDatabaseIfNeeded(string outputPath)
+        {
+            var assetsPath = Path.GetFullPath("Assets");
+            if (Path.GetFullPath(outputPath).StartsWith(assetsPath, StringComparison.OrdinalIgnoreCase))
+            {
+                AssetDatabase.Refresh();
+            }
+        }
+
+        private void DestroyPreviewTexture()
+        {
+            if (_outputPreview != null)
+            {
+                DestroyImmediate(_outputPreview);
+                _outputPreview = null;
+            }
+        }
+
+        private void SetStatus(string message, MessageType type)
+        {
+            _statusMessage = message;
+            _statusType = type;
+        }
+
+        private enum AspectPreset
+        {
+            Square,
+            Landscape4By3,
+            Portrait3By4,
+            Landscape16By9,
+            Portrait9By16,
+            Custom
         }
     }
 }


### PR DESCRIPTION
## 概要
- `Tools > Square Crop Editor > Open` の EditorWindow を実用MVP化
- source texture field を追加
- crop/output aspect ratio controls を追加（square default / presets / custom numeric ratio）
- output long edge / mapping / conflict / output path controls を追加
- source preview上で ratio-constrained drag selection overlay を表示
- checkerboard付き transparent output preview を追加
- `PngAspectExporter` に接続してPNG exportを実行

## 検証
- Unity `6000.4.0f1` 一時 project で package import / script compilation 成功
- `-executeMethod Issue6WindowSmoke.Run` で `ISSUE6_WINDOW_SMOKE=PASS`

Closes #6