### PR TITLE
feat: Read/Write disabled handling を追加

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Export.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Export.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6d29a1c63cfdf5b4da786d0ed3520a2b
+folderAsset: yes

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Editor.Export
+{
+    public readonly struct ReadableTextureResult
+    {
+        public ReadableTextureResult(bool success, Texture2D texture, bool ownsTexture, string message)
+        {
+            Success = success;
+            Texture = texture;
+            OwnsTexture = ownsTexture;
+            Message = message;
+        }
+
+        public bool Success { get; }
+
+        public Texture2D Texture { get; }
+
+        public bool OwnsTexture { get; }
+
+        public string Message { get; }
+    }
+
+    public static class TextureReadbackService
+    {
+        public static ReadableTextureResult GetReadableTexture(Texture2D sourceTexture)
+        {
+            if (sourceTexture == null)
+            {
+                return new ReadableTextureResult(false, null, false, "No source image selected.");
+            }
+
+            if (CanReadPixels(sourceTexture))
+            {
+                return new ReadableTextureResult(true, sourceTexture, false, "Source texture is readable.");
+            }
+
+            var assetPath = AssetDatabase.GetAssetPath(sourceTexture);
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                return new ReadableTextureResult(false, null, false, "Source texture cannot be read and is not a project asset.");
+            }
+
+            var fullPath = Path.GetFullPath(assetPath);
+            if (!File.Exists(fullPath))
+            {
+                return new ReadableTextureResult(false, null, false, $"Source texture file was not found: {assetPath}");
+            }
+
+            try
+            {
+                var readableTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false)
+                {
+                    name = sourceTexture.name + "_ReadableCopy",
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+
+                if (!ImageConversion.LoadImage(readableTexture, File.ReadAllBytes(fullPath), false))
+                {
+                    UnityEngine.Object.DestroyImmediate(readableTexture);
+                    return new ReadableTextureResult(false, null, false, $"Source texture file could not be decoded: {assetPath}");
+                }
+
+                return new ReadableTextureResult(true, readableTexture, true, "Created a temporary readable copy without changing importer settings.");
+            }
+            catch (Exception ex)
+            {
+                return new ReadableTextureResult(false, null, false, ex.Message);
+            }
+        }
+
+        public static bool CanReadPixels(Texture2D texture)
+        {
+            if (texture == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                texture.GetPixel(0, 0);
+                return true;
+            }
+            catch (UnityException)
+            {
+                return false;
+            }
+        }
+
+        public static void DestroyIfOwned(ReadableTextureResult result)
+        {
+            if (result.OwnsTexture && result.Texture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(result.Texture);
+            }
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8c0dfae5b054b438f324f943f53d0c8

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Sunmax0731.SquareCropEditor.Editor.Export;
 using Sunmax0731.SquareCropEditor.Models;
 using Sunmax0731.SquareCropEditor.Services;
 using UnityEditor;
@@ -95,7 +96,14 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 if (_sourceTexture != null)
                 {
                     _settings.OutputFileName = Path.GetFileNameWithoutExtension(AssetDatabase.GetAssetPath(_sourceTexture)) + SquareCropSettings.DefaultFileNameSuffix + ".png";
-                    SetStatus($"Source: {_sourceTexture.width} x {_sourceTexture.height}", MessageType.Info);
+                    if (TextureReadbackService.CanReadPixels(_sourceTexture))
+                    {
+                        SetStatus($"Source: {_sourceTexture.width} x {_sourceTexture.height}", MessageType.Info);
+                    }
+                    else
+                    {
+                        SetStatus("Source texture is not directly readable. Preview/export will use a temporary readable copy when possible.", MessageType.Warning);
+                    }
                 }
                 else
                 {
@@ -270,10 +278,24 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
             try
             {
-                var outputSize = AspectOutputPlanner.CalculateOutputSize(_settings.OutputSize, GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight));
-                var plan = AspectOutputPlanner.Plan(_selection, outputSize, _settings.MappingMode);
-                _outputPreview = PngAspectExporter.Render(_sourceTexture, plan);
-                SetStatus($"Selection: {_selection.Width} x {_selection.Height}", MessageType.Info);
+                var readable = TextureReadbackService.GetReadableTexture(_sourceTexture);
+                if (!readable.Success)
+                {
+                    SetStatus(readable.Message, MessageType.Error);
+                    return;
+                }
+
+                try
+                {
+                    var outputSize = AspectOutputPlanner.CalculateOutputSize(_settings.OutputSize, GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight));
+                    var plan = AspectOutputPlanner.Plan(_selection, outputSize, _settings.MappingMode);
+                    _outputPreview = PngAspectExporter.Render(readable.Texture, plan);
+                    SetStatus(readable.OwnsTexture ? $"Selection: {_selection.Width} x {_selection.Height}. Using temporary readable copy." : $"Selection: {_selection.Width} x {_selection.Height}", readable.OwnsTexture ? MessageType.Warning : MessageType.Info);
+                }
+                finally
+                {
+                    TextureReadbackService.DestroyIfOwned(readable);
+                }
             }
             catch (Exception ex)
             {
@@ -283,30 +305,44 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
         private void ExportPng()
         {
-            var result = PngAspectExporter.Export(new PngExportRequest
+            var readable = TextureReadbackService.GetReadableTexture(_sourceTexture);
+            if (!readable.Success)
             {
-                SourceTexture = _sourceTexture,
-                Selection = _selection,
-                OutputLongEdge = _settings.OutputSize,
-                OutputAspectRatio = GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight),
-                MappingMode = _settings.MappingMode,
-                OutputFolder = _settings.OutputFolder,
-                OutputFileName = _settings.OutputFileName,
-                ConflictBehavior = _settings.ConflictBehavior
-            });
+                SetStatus(readable.Message, MessageType.Error);
+                return;
+            }
 
-            if (result.Status == PngExportStatus.Exported)
+            try
             {
-                RefreshAssetDatabaseIfNeeded(result.OutputPath);
-                SetStatus($"Exported: {result.OutputPath}", MessageType.Info);
+                var result = PngAspectExporter.Export(new PngExportRequest
+                {
+                    SourceTexture = readable.Texture,
+                    Selection = _selection,
+                    OutputLongEdge = _settings.OutputSize,
+                    OutputAspectRatio = GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight),
+                    MappingMode = _settings.MappingMode,
+                    OutputFolder = _settings.OutputFolder,
+                    OutputFileName = _settings.OutputFileName,
+                    ConflictBehavior = _settings.ConflictBehavior
+                });
+
+                if (result.Status == PngExportStatus.Exported)
+                {
+                    RefreshAssetDatabaseIfNeeded(result.OutputPath);
+                    SetStatus(readable.OwnsTexture ? $"Exported with temporary readable copy: {result.OutputPath}" : $"Exported: {result.OutputPath}", readable.OwnsTexture ? MessageType.Warning : MessageType.Info);
+                }
+                else if (result.Status == PngExportStatus.Skipped)
+                {
+                    SetStatus(result.Message, MessageType.Warning);
+                }
+                else
+                {
+                    SetStatus(result.Message, MessageType.Error);
+                }
             }
-            else if (result.Status == PngExportStatus.Skipped)
+            finally
             {
-                SetStatus(result.Message, MessageType.Warning);
-            }
-            else
-            {
-                SetStatus(result.Message, MessageType.Error);
+                TextureReadbackService.DestroyIfOwned(readable);
             }
         }
 

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using NUnit.Framework;
+using Sunmax0731.SquareCropEditor.Editor.Export;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Tests.Editor
+{
+    public sealed class TextureReadbackServiceTests
+    {
+        private const string TestFolder = "Assets/TempSquareCropReadbackTests";
+        private const string TestTexturePath = TestFolder + "/source.png";
+
+        [TearDown]
+        public void TearDown()
+        {
+            AssetDatabase.DeleteAsset(TestFolder);
+            AssetDatabase.Refresh();
+        }
+
+        [Test]
+        public void CreatesTemporaryReadableCopyWithoutChangingImporter()
+        {
+            Directory.CreateDirectory(TestFolder);
+            File.WriteAllBytes(TestTexturePath, CreatePngBytes());
+            AssetDatabase.ImportAsset(TestTexturePath, ImportAssetOptions.ForceSynchronousImport);
+
+            var importer = (TextureImporter)AssetImporter.GetAtPath(TestTexturePath);
+            importer.isReadable = false;
+            importer.SaveAndReimport();
+
+            var source = AssetDatabase.LoadAssetAtPath<Texture2D>(TestTexturePath);
+            Assert.That(source, Is.Not.Null);
+            Assert.That(TextureReadbackService.CanReadPixels(source), Is.False);
+
+            var result = TextureReadbackService.GetReadableTexture(source);
+
+            Assert.That(result.Success, Is.True, result.Message);
+            Assert.That(result.OwnsTexture, Is.True);
+            Assert.That(TextureReadbackService.CanReadPixels(result.Texture), Is.True);
+            Assert.That(((TextureImporter)AssetImporter.GetAtPath(TestTexturePath)).isReadable, Is.False);
+
+            TextureReadbackService.DestroyIfOwned(result);
+        }
+
+        private static byte[] CreatePngBytes()
+        {
+            var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+            texture.SetPixels(new[]
+            {
+                Color.clear,
+                Color.red,
+                Color.green,
+                Color.blue
+            });
+            texture.Apply();
+            var bytes = ImageConversion.EncodeToPNG(texture);
+            Object.DestroyImmediate(texture);
+            return bytes;
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ee2ad8076ab4d47b81f0146f0d0ab41


### PR DESCRIPTION
## Summary
- Adds an Editor-side TextureReadbackService that creates temporary readable copies without changing source importers.
- Uses the readable-copy path for output preview and export when source textures are not directly readable.
- Adds validation/status messages for unreadable source handling and a regression test for importer-safe readback.

## Validation
- Temp Unity project: D:\Claude\UnityEditor-Dev\.tmp\unity-square-crop-editor-validation
- C:\Program Files\Unity\6000.0.25f1\Editor\Unity.exe -batchmode -nographics -projectPath <temp-project> -runTests -testPlatform EditMode -testResults <temp-project>\Validation\editmode-results.xml -logFile <temp-project>\Validation\unity-editmode.log
- Result: 17/17 passed

Closes #7