### PR TITLE
Fix selection/output position mapping

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -27,7 +27,8 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
         private int _customCropHeight = 1;
         private int _customOutputWidth = 1;
         private int _customOutputHeight = 1;
-        private Vector2 _dragStart;
+        private Vector2 _dragStartLocal;
+        private Rect _dragImageRect;
         private bool _isDragging;
         private string _statusMessage = "Select a source texture.";
         private MessageType _statusType = MessageType.Info;
@@ -219,21 +220,22 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
             if (currentEvent.type == EventType.MouseDown && currentEvent.button == 0 && imageRect.Contains(currentEvent.mousePosition))
             {
-                _dragStart = currentEvent.mousePosition;
+                _dragImageRect = imageRect;
+                _dragStartLocal = ClampLocalPoint(currentEvent.mousePosition - _dragImageRect.position, _dragImageRect);
                 _isDragging = true;
                 currentEvent.Use();
             }
 
             if (_isDragging && (currentEvent.type == EventType.MouseDrag || currentEvent.type == EventType.MouseUp))
             {
-                var localStart = _dragStart - imageRect.position;
-                var localEnd = currentEvent.mousePosition - imageRect.position;
+                var localStart = ClampLocalPoint(_dragStartLocal, _dragImageRect);
+                var localEnd = ClampLocalPoint(currentEvent.mousePosition - _dragImageRect.position, _dragImageRect);
                 _selection = CropRectCalculator.FromPreviewDrag(
                     localStart.x,
                     localStart.y,
                     localEnd.x,
                     localEnd.y,
-                    new PixelSize(Mathf.RoundToInt(imageRect.width), Mathf.RoundToInt(imageRect.height)),
+                    new PixelSize(Mathf.RoundToInt(_dragImageRect.width), Mathf.RoundToInt(_dragImageRect.height)),
                     new PixelSize(_sourceTexture.width, _sourceTexture.height),
                     GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
                 RefreshOutputPreview();
@@ -245,6 +247,13 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                     _isDragging = false;
                 }
             }
+        }
+
+        private static Vector2 ClampLocalPoint(Vector2 point, Rect imageRect)
+        {
+            return new Vector2(
+                Mathf.Clamp(point.x, 0f, imageRect.width),
+                Mathf.Clamp(point.y, 0f, imageRect.height));
         }
 
         private void DrawSelection(Rect imageRect)

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
@@ -88,6 +88,23 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void RenderUsesTopLeftSelectionCoordinates()
+        {
+            var source = CreatePositionTexture();
+            var output = PngAspectExporter.Render(
+                source,
+                AspectOutputPlanner.Plan(new CropSelection(1, 0, 2, 2), new PixelSize(2, 2), CanvasMappingMode.Stretch));
+
+            AssertColor(output, 0, 0, Color.red);
+            AssertColor(output, 1, 0, Color.green);
+            AssertColor(output, 0, 1, Color.blue);
+            AssertColor(output, 1, 1, Color.yellow);
+
+            UnityEngine.Object.DestroyImmediate(source);
+            UnityEngine.Object.DestroyImmediate(output);
+        }
+
+        [Test]
         public void SkipConflictDoesNotOverwriteExistingFile()
         {
             var existingPath = Path.Combine(_tempFolder, "icon.png");
@@ -199,6 +216,36 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
             texture.SetPixels(pixels);
             texture.Apply();
             return texture;
+        }
+
+        private static Texture2D CreatePositionTexture()
+        {
+            var texture = new Texture2D(4, 4, TextureFormat.RGBA32, false);
+            SetVisualPixel(texture, 1, 0, Color.red);
+            SetVisualPixel(texture, 2, 0, Color.green);
+            SetVisualPixel(texture, 1, 1, Color.blue);
+            SetVisualPixel(texture, 2, 1, Color.yellow);
+            texture.Apply();
+            return texture;
+        }
+
+        private static void AssertColor(Texture2D texture, int visualX, int visualY, Color expected)
+        {
+            var actual = GetVisualPixel(texture, visualX, visualY);
+            Assert.That(actual.r, Is.EqualTo(expected.r).Within(0.001f));
+            Assert.That(actual.g, Is.EqualTo(expected.g).Within(0.001f));
+            Assert.That(actual.b, Is.EqualTo(expected.b).Within(0.001f));
+            Assert.That(actual.a, Is.EqualTo(expected.a).Within(0.001f));
+        }
+
+        private static Color GetVisualPixel(Texture2D texture, int visualX, int visualY)
+        {
+            return texture.GetPixel(visualX, texture.height - 1 - visualY);
+        }
+
+        private static void SetVisualPixel(Texture2D texture, int visualX, int visualY, Color color)
+        {
+            texture.SetPixel(visualX, texture.height - 1 - visualY, color);
         }
 
         private static Texture2D LoadPng(string path)


### PR DESCRIPTION
## Summary
- Fix drag selection to keep the MouseDown image rect as the coordinate basis during the drag
- Clamp drag endpoints in preview-local coordinates before converting to source pixels
- Add a regression test that verifies top-left selection coordinates map to the same visual output pixels

## Validation
- Unity 6000.4.0f1 EditMode tests on temp project copy: 18 passed, 0 failed
- Result XML: %TEMP%\\unity-square-crop-editor-validation-issue22\\Validation\\editmode-results.xml

Closes #22