### PR TITLE
Fix output preview readback for imported textures

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Export/TextureReadbackService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -38,37 +37,39 @@ namespace Sunmax0731.SquareCropEditor.Editor.Export
                 return new ReadableTextureResult(true, sourceTexture, false, "Source texture is readable.");
             }
 
-            var assetPath = AssetDatabase.GetAssetPath(sourceTexture);
-            if (string.IsNullOrEmpty(assetPath))
-            {
-                return new ReadableTextureResult(false, null, false, "Source texture cannot be read and is not a project asset.");
-            }
-
-            var fullPath = Path.GetFullPath(assetPath);
-            if (!File.Exists(fullPath))
-            {
-                return new ReadableTextureResult(false, null, false, $"Source texture file was not found: {assetPath}");
-            }
-
             try
             {
-                var readableTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false)
-                {
-                    name = sourceTexture.name + "_ReadableCopy",
-                    hideFlags = HideFlags.HideAndDontSave
-                };
-
-                if (!ImageConversion.LoadImage(readableTexture, File.ReadAllBytes(fullPath), false))
-                {
-                    UnityEngine.Object.DestroyImmediate(readableTexture);
-                    return new ReadableTextureResult(false, null, false, $"Source texture file could not be decoded: {assetPath}");
-                }
-
-                return new ReadableTextureResult(true, readableTexture, true, "Created a temporary readable copy without changing importer settings.");
+                var readableTexture = CreateReadableCopy(sourceTexture);
+                return new ReadableTextureResult(true, readableTexture, true, "Created a temporary readable copy from the imported texture without changing importer settings.");
             }
             catch (Exception ex)
             {
                 return new ReadableTextureResult(false, null, false, ex.Message);
+            }
+        }
+
+        private static Texture2D CreateReadableCopy(Texture2D sourceTexture)
+        {
+            var previousActive = RenderTexture.active;
+            var renderTexture = RenderTexture.GetTemporary(sourceTexture.width, sourceTexture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Default);
+            try
+            {
+                Graphics.Blit(sourceTexture, renderTexture);
+                RenderTexture.active = renderTexture;
+
+                var readableTexture = new Texture2D(sourceTexture.width, sourceTexture.height, TextureFormat.RGBA32, false)
+                {
+                    name = sourceTexture.name + "_ReadableCopy",
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+                readableTexture.ReadPixels(new Rect(0, 0, sourceTexture.width, sourceTexture.height), 0, 0);
+                readableTexture.Apply(false, false);
+                return readableTexture;
+            }
+            finally
+            {
+                RenderTexture.active = previousActive;
+                RenderTexture.ReleaseTemporary(renderTexture);
             }
         }
 

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/TextureReadbackServiceTests.cs
@@ -43,16 +43,65 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
             TextureReadbackService.DestroyIfOwned(result);
         }
 
+        [Test]
+        public void TemporaryReadableCopyUsesImportedTextureDimensions()
+        {
+            Directory.CreateDirectory(TestFolder);
+            File.WriteAllBytes(TestTexturePath, CreatePngBytes(64, 32));
+            AssetDatabase.ImportAsset(TestTexturePath, ImportAssetOptions.ForceSynchronousImport);
+
+            var importer = (TextureImporter)AssetImporter.GetAtPath(TestTexturePath);
+            importer.isReadable = false;
+            importer.maxTextureSize = 16;
+            importer.textureCompression = TextureImporterCompression.Uncompressed;
+            importer.SaveAndReimport();
+
+            var source = AssetDatabase.LoadAssetAtPath<Texture2D>(TestTexturePath);
+            Assert.That(source, Is.Not.Null);
+            Assert.That(source.width, Is.LessThan(64));
+            Assert.That(source.height, Is.LessThan(32));
+            Assert.That(TextureReadbackService.CanReadPixels(source), Is.False);
+
+            var result = TextureReadbackService.GetReadableTexture(source);
+
+            Assert.That(result.Success, Is.True, result.Message);
+            Assert.That(result.OwnsTexture, Is.True);
+            Assert.That(result.Texture.width, Is.EqualTo(source.width));
+            Assert.That(result.Texture.height, Is.EqualTo(source.height));
+            Assert.That(TextureReadbackService.CanReadPixels(result.Texture), Is.True);
+
+            TextureReadbackService.DestroyIfOwned(result);
+        }
+
         private static byte[] CreatePngBytes()
         {
-            var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
-            texture.SetPixels(new[]
+            return CreatePngBytes(2, 2);
+        }
+
+        private static byte[] CreatePngBytes(int width, int height)
+        {
+            var texture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+            var pixels = new Color[width * height];
+            for (var y = 0; y < height; y++)
             {
-                Color.clear,
-                Color.red,
-                Color.green,
-                Color.blue
-            });
+                for (var x = 0; x < width; x++)
+                {
+                    pixels[y * width + x] = new Color((float)x / width, (float)y / height, 1f, 1f);
+                }
+            }
+
+            if (width == 2 && height == 2)
+            {
+                pixels = new[]
+                {
+                    Color.clear,
+                    Color.red,
+                    Color.green,
+                    Color.blue
+                };
+            }
+
+            texture.SetPixels(pixels);
             texture.Apply();
             var bytes = ImageConversion.EncodeToPNG(texture);
             Object.DestroyImmediate(texture);


### PR DESCRIPTION
## Summary
- Reopen and continue #22 after Smoke Test showed the selection/output mismatch was still present
- Replace file-based unreadable texture fallback with GPU readback from the imported Texture2D
- Keep Output preview/export coordinates aligned with the same imported dimensions shown in Source preview
- Add regression coverage for imported textures resized by importer settings

## Validation
- Unity 6000.4.0f1 EditMode tests on temp project copy: 19 passed, 0 failed
- Result XML: %TEMP%\\unity-square-crop-editor-validation-issue22b\\Validation\\editmode-results.xml

Closes #22