### PR TITLE
Add release packaging flow

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Release.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Release.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39d4175343724d141bd82e21fcc800d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Release/UnityPackageExporter.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Release/UnityPackageExporter.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sunmax0731.SquareCropEditor.Editor.Release
+{
+    public static class UnityPackageExporter
+    {
+        private const string PackageRoot = "Packages/com.sunmax0731.square-crop-editor";
+        private const string OutputArgument = "-squareCropUnityPackageOutput";
+
+        public static void ExportFromCommandLine()
+        {
+            var outputPath = GetArgumentValue(OutputArgument);
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new ArgumentException($"{OutputArgument} is required.");
+            }
+
+            outputPath = Path.GetFullPath(outputPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+
+            AssetDatabase.ExportPackage(
+                PackageRoot,
+                outputPath,
+                ExportPackageOptions.Recurse);
+
+            if (!File.Exists(outputPath))
+            {
+                throw new IOException($"Unity package was not created: {outputPath}");
+            }
+
+            Debug.Log($"Exported Unity package: {outputPath}");
+        }
+
+        private static string GetArgumentValue(string argumentName)
+        {
+            var args = Environment.GetCommandLineArgs();
+            for (var index = 0; index < args.Length - 1; index++)
+            {
+                if (args[index] == argumentName)
+                {
+                    return args[index + 1];
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Release/UnityPackageExporter.cs.meta
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Release/UnityPackageExporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26e39d611fabacc46bc60685ed17d187

--- a/Packages/com.sunmax0731.square-crop-editor/ValidationChecklist.md
+++ b/Packages/com.sunmax0731.square-crop-editor/ValidationChecklist.md
@@ -42,6 +42,21 @@ $unity = 'C:\Program Files\Unity\6000.4.0f1\Editor\Unity.exe'
 - [ ] `ValidationChecklist.md`
 - [ ] `Samples~/TransparentIconSource`
 
+## Release Packaging
+
+- [ ] Run the release packaging script.
+- [ ] Confirm the release zip name matches the package version.
+- [ ] Confirm the release zip contains the UPM package folder.
+- [ ] Confirm the release zip contains the unitypackage.
+- [ ] Confirm the release zip contains `GitHubReleaseBody.ja.md`.
+- [ ] Confirm the release zip contains `BOOTHDescription.ja.md`.
+
+Suggested command:
+
+```powershell
+.\tools\release\New-ReleasePackage.ps1
+```
+
 ## Known Limitations Confirmed
 
 - [ ] Batch export is not listed as supported.

--- a/tools/release/BOOTHDescription.ja.md
+++ b/tools/release/BOOTHDescription.ja.md
@@ -1,0 +1,36 @@
+# Unity Square Crop Editor
+
+Unity Editor上で画像の一部をドラッグ選択し、正方形や任意のアスペクト比のPNGとして書き出すEditor拡張です。
+
+透明PNGのアイコン素材、UI素材、サムネイル素材などから、必要な範囲だけを切り出してPNG化する用途を想定しています。
+
+## 主な機能
+
+- Unity Editor内の専用Windowで操作
+- Source Imageを指定してドラッグでcrop範囲を選択
+- 正方形、4:3、3:4、16:9、9:16、Custom ratioに対応
+- Output sizeをlong edge基準で指定
+- `Fit` / `Fill` / `Stretch` の出力方式
+- 透明背景を保持したPNG書き出し
+- Read/Write disabled textureでも、import設定を恒久変更せず一時コピーで処理
+
+## 内容物
+
+- UPM package
+- unitypackage
+- Manual / Manual.ja
+- ReleaseNotes
+- TermsOfUse
+- ValidationChecklist
+- サンプル画像
+
+## 動作環境
+
+- Unity 6000.0 以降
+- 検証環境: Unity 6000.4.0f1
+
+## 注意事項
+
+- v0.1.0では単一画像、単一選択のPNG exportに特化しています。
+- batch export、object detection、mask editing、atlas/grid slicingには対応していません。
+- 本ツールはUnity Grid Asset Slicerとは独立したEditor拡張です。

--- a/tools/release/GitHubReleaseBody.ja.md
+++ b/tools/release/GitHubReleaseBody.ja.md
@@ -1,0 +1,37 @@
+# Unity Square Crop Editor v0.1.0
+
+Unity Editor上で透明PNGなどの画像をドラッグ選択し、指定したアスペクト比のPNGとして書き出すEditor拡張です。
+
+## 内容物
+
+- `com.sunmax0731.square-crop-editor/` UPM package
+- `UnitySquareCropEditor-v0.1.0.unitypackage`
+- Manual / Manual.ja
+- TermsOfUse
+- ReleaseNotes
+- ValidationChecklist
+- Transparent Icon Source sample
+- BOOTHDescription.ja.md
+
+## 主な機能
+
+- `Tools > Square Crop Editor > Open` からEditor Windowを起動
+- Source Imageを選択してプレビュー上でドラッグ選択
+- Square / 4:3 / 3:4 / 16:9 / 9:16 / Custom のcrop ratio
+- Output ratioとlong edge sizeの指定
+- `Fit` / `Fill` / `Stretch` mapping
+- 透明背景を維持したPNG export
+- Read/Write disabled textureの一時readable copy処理
+
+## 検証
+
+- Unity 6000.4.0f1
+- EditMode tests
+- Manual smoke checklist: `ValidationChecklist.md`
+
+## 制限事項
+
+- 単一画像、単一選択のみ
+- PNG exportのみ
+- batch export、object detection、mask editing、atlas/grid slicingは対象外
+- session JSON / preset persistenceは未対応

--- a/tools/release/New-ReleasePackage.ps1
+++ b/tools/release/New-ReleasePackage.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectPath = '',
+    [string]$UnityPath = 'C:\Program Files\Unity\6000.4.0f1\Editor\Unity.exe',
+    [switch]$SkipValidation
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Unity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$StepName
+    )
+
+    $process = Start-Process -FilePath $UnityPath -ArgumentList $Arguments -Wait -PassThru
+    if ($process.ExitCode -ne 0) {
+        throw "$StepName failed with exit code $($process.ExitCode)."
+    }
+}
+
+function Assert-TestResultsPassed {
+    param([Parameter(Mandatory = $true)][string]$ResultsPath)
+
+    if (-not (Test-Path -LiteralPath $ResultsPath)) {
+        throw "Unity test results were not created: $ResultsPath"
+    }
+
+    [xml]$results = Get-Content -LiteralPath $ResultsPath -Raw
+    $testRun = $results.'test-run'
+    if ($testRun.result -ne 'Passed' -or [int]$testRun.failed -ne 0) {
+        throw "Unity EditMode tests did not pass. result=$($testRun.result), failed=$($testRun.failed)"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($ProjectPath)) {
+    $ProjectPath = Join-Path $PSScriptRoot '..\..'
+}
+
+$ProjectPath = (Resolve-Path $ProjectPath).Path
+if (-not (Test-Path -LiteralPath $UnityPath)) {
+    throw "Unity executable was not found: $UnityPath"
+}
+
+$packageRoot = Join-Path $ProjectPath 'Packages\com.sunmax0731.square-crop-editor'
+$packageJsonPath = Join-Path $packageRoot 'package.json'
+$packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+$version = $packageJson.version
+$packageName = $packageJson.name
+$artifactName = "UnitySquareCropEditor-v$version"
+$releaseRoot = Join-Path $ProjectPath "ReleaseBuilds\v$version"
+$stagingRoot = Join-Path $releaseRoot 'zip-staging'
+$validationRoot = Join-Path $ProjectPath 'Validation'
+$testResultsPath = Join-Path $validationRoot 'editmode-results.xml'
+$testLogPath = Join-Path $validationRoot 'unity-editmode.log'
+$unityPackagePath = Join-Path $releaseRoot "$artifactName.unitypackage"
+$unityPackageLogPath = Join-Path $validationRoot 'unitypackage-export.log'
+$zipPath = Join-Path $releaseRoot "$artifactName.zip"
+
+New-Item -ItemType Directory -Path $releaseRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $validationRoot -Force | Out-Null
+
+if (-not $SkipValidation) {
+    Remove-Item -LiteralPath $testResultsPath -ErrorAction SilentlyContinue
+    Invoke-Unity -StepName 'EditMode validation' -Arguments @(
+        '-batchmode',
+        '-projectPath', $ProjectPath,
+        '-runTests',
+        '-testPlatform', 'EditMode',
+        '-assemblyNames', 'Sunmax0731.SquareCropEditor.Editor.Tests',
+        '-testResults', $testResultsPath,
+        '-logFile', $testLogPath
+    )
+    Assert-TestResultsPassed -ResultsPath $testResultsPath
+}
+
+Remove-Item -LiteralPath $unityPackagePath -ErrorAction SilentlyContinue
+Invoke-Unity -StepName 'Unity package export' -Arguments @(
+    '-batchmode',
+    '-quit',
+    '-projectPath', $ProjectPath,
+    '-executeMethod', 'Sunmax0731.SquareCropEditor.Editor.Release.UnityPackageExporter.ExportFromCommandLine',
+    '-squareCropUnityPackageOutput', $unityPackagePath,
+    '-logFile', $unityPackageLogPath
+)
+
+if (-not (Test-Path -LiteralPath $unityPackagePath)) {
+    throw "Unity package was not created: $unityPackagePath"
+}
+
+Remove-Item -LiteralPath $stagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+
+$packageDestination = Join-Path $stagingRoot $packageName
+Copy-Item -LiteralPath $packageRoot -Destination $packageDestination -Recurse
+Copy-Item -LiteralPath $unityPackagePath -Destination (Join-Path $stagingRoot (Split-Path $unityPackagePath -Leaf))
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'GitHubReleaseBody.ja.md') -Destination (Join-Path $stagingRoot 'GitHubReleaseBody.ja.md')
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'BOOTHDescription.ja.md') -Destination (Join-Path $stagingRoot 'BOOTHDescription.ja.md')
+
+Remove-Item -LiteralPath $zipPath -ErrorAction SilentlyContinue
+Compress-Archive -Path (Join-Path $stagingRoot '*') -DestinationPath $zipPath -Force
+
+& (Join-Path $PSScriptRoot 'Test-ReleasePackage.ps1') -ZipPath $zipPath -PackageName $packageName -Version $version
+
+Write-Host "Release artifacts created:"
+Write-Host "  $zipPath"
+Write-Host "  $unityPackagePath"

--- a/tools/release/Test-ReleasePackage.ps1
+++ b/tools/release/Test-ReleasePackage.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ZipPath,
+    [Parameter(Mandatory = $true)]
+    [string]$PackageName,
+    [Parameter(Mandatory = $true)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ZipPath)) {
+    throw "Release zip was not found: $ZipPath"
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path $ZipPath).Path)
+try {
+    $entries = @($zip.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+    $artifactName = "UnitySquareCropEditor-v$Version"
+    $requiredEntries = @(
+        "$artifactName.unitypackage",
+        "$PackageName/package.json",
+        "$PackageName/README.md",
+        "$PackageName/Manual.md",
+        "$PackageName/Manual.ja.md",
+        "$PackageName/TermsOfUse.md",
+        "$PackageName/ReleaseNotes.md",
+        "$PackageName/ValidationChecklist.md",
+        "$PackageName/Samples~/TransparentIconSource/README.md",
+        "$PackageName/Samples~/TransparentIconSource/square-crop-sample.png",
+        'GitHubReleaseBody.ja.md',
+        'BOOTHDescription.ja.md'
+    )
+
+    foreach ($entry in $requiredEntries) {
+        if ($entries -notcontains $entry) {
+            throw "Release zip is missing required entry: $entry"
+        }
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+Write-Host "Release zip contents validated: $ZipPath"


### PR DESCRIPTION
## Summary
- Add Unity batchmode entrypoint for exporting the package as a .unitypackage
- Add 	ools/release/New-ReleasePackage.ps1 to run validation, export unitypackage, build release zip, and validate required contents
- Add standalone Test-ReleasePackage.ps1
- Add Japanese GitHub Release body and BOOTH description drafts
- Extend ValidationChecklist.md with release packaging checks

## Validation
- powershell -ExecutionPolicy Bypass -File .\\tools\\release\\New-ReleasePackage.ps1
- Generated ReleaseBuilds/v0.1.0/UnitySquareCropEditor-v0.1.0.zip
- Generated ReleaseBuilds/v0.1.0/UnitySquareCropEditor-v0.1.0.unitypackage
- Zip contents validation passed
- Unity 6000.4.0f1 EditMode tests: 19 passed, 0 failed

Closes #9