### PR TITLE
Add selection action controls

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -81,6 +81,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 }
             }
 
+            DrawSelectionActions();
             DrawPreviewArea();
             DrawExportButton();
         }
@@ -164,6 +165,36 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 if (GUILayout.Button(".png", GUILayout.Width(48)))
                 {
                     _settings.OutputFileName = EnsurePngExtension(_settings.OutputFileName);
+                }
+            }
+        }
+
+        private void DrawSelectionActions()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (new EditorGUI.DisabledScope(_sourceTexture == null))
+                {
+                    if (GUILayout.Button("Reset Selection"))
+                    {
+                        _selection = default;
+                        DestroyPreviewTexture();
+                        SetStatus("Selection reset.", MessageType.Info);
+                    }
+
+                    if (GUILayout.Button("Use Full Source"))
+                    {
+                        _selection = CropRectCalculator.FullSource(new PixelSize(_sourceTexture.width, _sourceTexture.height));
+                        RefreshOutputPreview();
+                    }
+
+                    if (GUILayout.Button("Center Crop"))
+                    {
+                        _selection = CropRectCalculator.CenterCrop(
+                            new PixelSize(_sourceTexture.width, _sourceTexture.height),
+                            GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                        RefreshOutputPreview();
+                    }
                 }
             }
         }

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
@@ -5,6 +5,47 @@ namespace Sunmax0731.SquareCropEditor.Services
 {
     public static class CropRectCalculator
     {
+        public static CropSelection FullSource(PixelSize sourceSize)
+        {
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            return new CropSelection(0, 0, sourceSize.Width, sourceSize.Height);
+        }
+
+        public static CropSelection CenterCrop(PixelSize sourceSize, AspectRatioSpec aspectRatio)
+        {
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            if (!aspectRatio.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(aspectRatio), "Aspect ratio must be positive.");
+            }
+
+            var sourceRatio = (double)sourceSize.Width / sourceSize.Height;
+            var targetRatio = aspectRatio.Value;
+            var width = sourceSize.Width;
+            var height = sourceSize.Height;
+
+            if (sourceRatio > targetRatio)
+            {
+                width = Math.Max(1, (int)Math.Round(sourceSize.Height * targetRatio));
+            }
+            else if (sourceRatio < targetRatio)
+            {
+                height = Math.Max(1, (int)Math.Round(sourceSize.Width / targetRatio));
+            }
+
+            var x = Math.Max(0, (sourceSize.Width - width) / 2);
+            var y = Math.Max(0, (sourceSize.Height - height) / 2);
+            return new CropSelection(x, y, width, height);
+        }
+
         public static CropSelection FromPreviewDrag(
             double startX,
             double startY,

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -61,6 +61,24 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void FullSourceUsesEntireSourceBounds()
+        {
+            var selection = CropRectCalculator.FullSource(new PixelSize(320, 180));
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(0, 0, 320, 180)));
+        }
+
+        [Test]
+        public void CenterCropUsesLargestCenteredAreaForTargetRatio()
+        {
+            var selection = CropRectCalculator.CenterCrop(
+                new PixelSize(320, 180),
+                AspectRatioSpec.Square);
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(70, 0, 180, 180)));
+        }
+
+        [Test]
         public void FitMapsFullSourceInsideTransparentCanvasArea()
         {
             var plan = AspectOutputPlanner.Plan(


### PR DESCRIPTION
## Summary
- Add Reset Selection, Use Full Source, and Center Crop actions to the Editor Window
- Add reusable crop helpers for full-source and ratio-constrained center crop selections
- Add EditMode coverage for the new crop helper behavior

## Validation
- Unity 6000.4.0f1 EditMode tests on this repository: 21 passed, 0 failed
- Result XML: Validation/editmode-results.xml

Closes #28