### PR TITLE
Clarify export validation messages

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
@@ -21,7 +21,7 @@ namespace Sunmax0731.SquareCropEditor.Services
 
             if (string.IsNullOrEmpty(conflictPath))
             {
-                return new PngExportResult(PngExportStatus.Skipped, outputPath, outputSize, "Output file already exists.");
+                return new PngExportResult(PngExportStatus.Skipped, outputPath, outputSize, $"Output file already exists and Conflict is set to Skip: {outputPath}");
             }
 
             try
@@ -38,7 +38,7 @@ namespace Sunmax0731.SquareCropEditor.Services
             }
             catch (Exception ex)
             {
-                return new PngExportResult(PngExportStatus.Error, conflictPath, outputSize, ex.Message);
+                return new PngExportResult(PngExportStatus.Error, conflictPath, outputSize, $"Failed to export PNG to '{conflictPath}': {ex.Message}");
             }
         }
 
@@ -116,17 +116,17 @@ namespace Sunmax0731.SquareCropEditor.Services
 
             if (string.IsNullOrWhiteSpace(request.OutputFolder))
             {
-                return "Output folder is missing.";
+                return "Output folder is missing. Choose an output folder or restore the default folder.";
             }
 
             if (string.IsNullOrWhiteSpace(request.OutputFileName))
             {
-                return "Output file name is missing.";
+                return "Output file name is missing. Enter a PNG file name.";
             }
 
             if (request.OutputFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
             {
-                return "Output file name contains invalid characters.";
+                return $"Output file name contains invalid characters: {request.OutputFileName}";
             }
 
             return string.Empty;

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
@@ -124,6 +124,8 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
             });
 
             Assert.That(result.Status, Is.EqualTo(PngExportStatus.Skipped));
+            Assert.That(result.Message, Does.Contain("Conflict is set to Skip"));
+            Assert.That(result.Message, Does.Contain(Path.GetFullPath(existingPath)));
             Assert.That(File.ReadAllText(existingPath), Is.EqualTo("existing"));
 
             UnityEngine.Object.DestroyImmediate(source);
@@ -196,7 +198,7 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
             });
 
             Assert.That(result.Status, Is.EqualTo(PngExportStatus.Error));
-            Assert.That(result.Message, Is.EqualTo("Output file name is missing."));
+            Assert.That(result.Message, Is.EqualTo("Output file name is missing. Enter a PNG file name."));
 
             UnityEngine.Object.DestroyImmediate(source);
         }


### PR DESCRIPTION
## Summary
- Clarify Skip conflict status with the current conflict mode and output path
- Clarify missing output file name guidance
- Include the destination path when PNG export fails during file writing
- Update tests for the clearer messages

## Validation
- Unity 6000.4.0f1 EditMode tests on this repository: 21 passed, 0 failed
- Result XML: Validation/editmode-results.xml

Closes #32