### PR TITLE
Add manual selection fields

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -83,6 +83,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             }
 
             DrawSelectionActions();
+            DrawSelectionFields();
             DrawPreviewArea();
             DrawExportButton();
         }
@@ -195,6 +196,36 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                             new PixelSize(_sourceTexture.width, _sourceTexture.height),
                             GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
                         RefreshOutputPreview();
+                    }
+                }
+            }
+        }
+
+        private void DrawSelectionFields()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (new EditorGUI.DisabledScope(_sourceTexture == null || !_selection.IsValid))
+                {
+                    EditorGUILayout.LabelField("Selection", GUILayout.Width(64));
+                    using (var change = new EditorGUI.ChangeCheckScope())
+                    {
+                        var x = EditorGUILayout.IntField("X", _selection.IsValid ? _selection.X : 0, GUILayout.MaxWidth(96));
+                        var y = EditorGUILayout.IntField("Y", _selection.IsValid ? _selection.Y : 0, GUILayout.MaxWidth(96));
+                        var width = EditorGUILayout.IntField("W", _selection.IsValid ? _selection.Width : 0, GUILayout.MaxWidth(96));
+                        var height = EditorGUILayout.IntField("H", _selection.IsValid ? _selection.Height : 0, GUILayout.MaxWidth(96));
+
+                        if (change.changed)
+                        {
+                            _selection = CropRectCalculator.FromManualInput(
+                                x,
+                                y,
+                                width,
+                                height,
+                                new PixelSize(_sourceTexture.width, _sourceTexture.height),
+                                GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                            RefreshOutputPreview();
+                        }
                     }
                 }
             }

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
@@ -46,6 +46,55 @@ namespace Sunmax0731.SquareCropEditor.Services
             return new CropSelection(x, y, width, height);
         }
 
+        public static CropSelection FromManualInput(
+            int x,
+            int y,
+            int width,
+            int height,
+            PixelSize sourceSize,
+            AspectRatioSpec aspectRatio)
+        {
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            if (!aspectRatio.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(aspectRatio), "Aspect ratio must be positive.");
+            }
+
+            var clampedWidth = Math.Max(1, Math.Min(width, sourceSize.Width));
+            var clampedHeight = Math.Max(1, Math.Min(height, sourceSize.Height));
+            var ratio = aspectRatio.Value;
+
+            if ((double)clampedWidth / clampedHeight > ratio)
+            {
+                clampedWidth = Math.Max(1, (int)Math.Round(clampedHeight * ratio));
+            }
+            else
+            {
+                clampedHeight = Math.Max(1, (int)Math.Round(clampedWidth / ratio));
+            }
+
+            if (clampedWidth > sourceSize.Width)
+            {
+                clampedWidth = sourceSize.Width;
+                clampedHeight = Math.Max(1, (int)Math.Round(clampedWidth / ratio));
+            }
+
+            if (clampedHeight > sourceSize.Height)
+            {
+                clampedHeight = sourceSize.Height;
+                clampedWidth = Math.Max(1, (int)Math.Round(clampedHeight * ratio));
+            }
+
+            var clampedX = Math.Max(0, Math.Min(x, sourceSize.Width - clampedWidth));
+            var clampedY = Math.Max(0, Math.Min(y, sourceSize.Height - clampedHeight));
+
+            return new CropSelection(clampedX, clampedY, clampedWidth, clampedHeight);
+        }
+
         public static CropSelection FromPreviewDrag(
             double startX,
             double startY,

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -79,6 +79,20 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void ManualInputClampsToBoundsAndTargetRatio()
+        {
+            var selection = CropRectCalculator.FromManualInput(
+                95,
+                95,
+                100,
+                50,
+                new PixelSize(120, 100),
+                AspectRatioSpec.Square);
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(70, 50, 50, 50)));
+        }
+
+        [Test]
         public void FitMapsFullSourceInsideTransparentCanvasArea()
         {
             var plan = AspectOutputPlanner.Plan(


### PR DESCRIPTION
## Summary
- Add visible X / Y / W / H selection fields to the Editor Window
- Allow manual selection adjustment after a crop exists
- Clamp manual input to source bounds and the active crop ratio
- Add EditMode coverage for manual input clamping

## Validation
- Unity 6000.4.0f1 EditMode tests on this repository: 22 passed, 0 failed
- Result XML: Validation/editmode-results.xml

Closes #27