### PR TITLE
Add free crop ratio mode

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -194,9 +194,12 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
                     if (GUILayout.Button("Center Crop"))
                     {
-                        _selection = CropRectCalculator.CenterCrop(
-                            new PixelSize(_sourceTexture.width, _sourceTexture.height),
-                            GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                        var sourceSize = new PixelSize(_sourceTexture.width, _sourceTexture.height);
+                        _selection = _cropPreset == AspectPreset.Free
+                            ? CropRectCalculator.FullSource(sourceSize)
+                            : CropRectCalculator.CenterCrop(
+                                sourceSize,
+                                GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
                         RefreshOutputPreview();
                     }
                 }
@@ -219,13 +222,16 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
                         if (change.changed)
                         {
-                            _selection = CropRectCalculator.FromManualInput(
-                                x,
-                                y,
-                                width,
-                                height,
-                                new PixelSize(_sourceTexture.width, _sourceTexture.height),
-                                GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                            var sourceSize = new PixelSize(_sourceTexture.width, _sourceTexture.height);
+                            _selection = _cropPreset == AspectPreset.Free
+                                ? CropRectCalculator.FromManualInput(x, y, width, height, sourceSize)
+                                : CropRectCalculator.FromManualInput(
+                                    x,
+                                    y,
+                                    width,
+                                    height,
+                                    sourceSize,
+                                    GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
                             RefreshOutputPreview();
                         }
                     }
@@ -356,14 +362,24 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 var clampedMousePosition = ClampPointToRect(currentEvent.mousePosition, previewRect);
                 var localStart = ClampLocalPoint(_dragStartLocal, _dragImageRect);
                 var localEnd = ClampLocalPoint(clampedMousePosition - _dragImageRect.position, _dragImageRect);
-                _selection = CropRectCalculator.FromPreviewDrag(
-                    localStart.x,
-                    localStart.y,
-                    localEnd.x,
-                    localEnd.y,
-                    new PixelSize(Mathf.RoundToInt(_dragImageRect.width), Mathf.RoundToInt(_dragImageRect.height)),
-                    new PixelSize(_sourceTexture.width, _sourceTexture.height),
-                    GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                var previewSize = new PixelSize(Mathf.RoundToInt(_dragImageRect.width), Mathf.RoundToInt(_dragImageRect.height));
+                var sourceSize = new PixelSize(_sourceTexture.width, _sourceTexture.height);
+                _selection = _cropPreset == AspectPreset.Free
+                    ? CropRectCalculator.FromPreviewDrag(
+                        localStart.x,
+                        localStart.y,
+                        localEnd.x,
+                        localEnd.y,
+                        previewSize,
+                        sourceSize)
+                    : CropRectCalculator.FromPreviewDrag(
+                        localStart.x,
+                        localStart.y,
+                        localEnd.x,
+                        localEnd.y,
+                        previewSize,
+                        sourceSize,
+                        GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
                 RefreshOutputPreview();
                 Repaint();
                 currentEvent.Use();
@@ -536,6 +552,8 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                     return AspectRatioSpec.Portrait9By16;
                 case AspectPreset.Custom:
                     return new AspectRatioSpec(Mathf.Max(1, customWidth), Mathf.Max(1, customHeight));
+                case AspectPreset.Free:
+                    return AspectRatioSpec.Square;
                 default:
                     return AspectRatioSpec.Square;
             }
@@ -687,6 +705,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
 
         private enum AspectPreset
         {
+            Free,
             Square,
             Landscape4By3,
             Portrait3By4,

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
@@ -51,6 +51,25 @@ namespace Sunmax0731.SquareCropEditor.Services
             int y,
             int width,
             int height,
+            PixelSize sourceSize)
+        {
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            var clampedWidth = Math.Max(1, Math.Min(width, sourceSize.Width));
+            var clampedHeight = Math.Max(1, Math.Min(height, sourceSize.Height));
+            var clampedX = Math.Max(0, Math.Min(x, sourceSize.Width - clampedWidth));
+            var clampedY = Math.Max(0, Math.Min(y, sourceSize.Height - clampedHeight));
+            return new CropSelection(clampedX, clampedY, clampedWidth, clampedHeight);
+        }
+
+        public static CropSelection FromManualInput(
+            int x,
+            int y,
+            int width,
+            int height,
             PixelSize sourceSize,
             AspectRatioSpec aspectRatio)
         {
@@ -93,6 +112,46 @@ namespace Sunmax0731.SquareCropEditor.Services
             var clampedY = Math.Max(0, Math.Min(y, sourceSize.Height - clampedHeight));
 
             return new CropSelection(clampedX, clampedY, clampedWidth, clampedHeight);
+        }
+
+        public static CropSelection FromPreviewDrag(
+            double startX,
+            double startY,
+            double endX,
+            double endY,
+            PixelSize previewSize,
+            PixelSize sourceSize)
+        {
+            if (!previewSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(previewSize), "Preview size must be positive.");
+            }
+
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            var sourceStartX = Clamp(startX * sourceSize.Width / previewSize.Width, 0, sourceSize.Width);
+            var sourceStartY = Clamp(startY * sourceSize.Height / previewSize.Height, 0, sourceSize.Height);
+            var sourceEndX = Clamp(endX * sourceSize.Width / previewSize.Width, 0, sourceSize.Width);
+            var sourceEndY = Clamp(endY * sourceSize.Height / previewSize.Height, 0, sourceSize.Height);
+
+            var x = Math.Min(sourceStartX, sourceEndX);
+            var y = Math.Min(sourceStartY, sourceEndY);
+            var width = Math.Abs(sourceEndX - sourceStartX);
+            var height = Math.Abs(sourceEndY - sourceStartY);
+
+            if (width <= 0 && height <= 0)
+            {
+                return new CropSelection((int)Math.Round(sourceStartX), (int)Math.Round(sourceStartY), 0, 0);
+            }
+
+            var roundedWidth = Math.Max(1, (int)Math.Round(width));
+            var roundedHeight = Math.Max(1, (int)Math.Round(height));
+            var roundedX = Math.Max(0, Math.Min((int)Math.Round(x), sourceSize.Width - roundedWidth));
+            var roundedY = Math.Max(0, Math.Min((int)Math.Round(y), sourceSize.Height - roundedHeight));
+            return new CropSelection(roundedX, roundedY, roundedWidth, roundedHeight);
         }
 
         public static CropSelection FromPreviewDrag(

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -61,6 +61,20 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void FreeCropDragDoesNotConstrainAspectRatio()
+        {
+            var selection = CropRectCalculator.FromPreviewDrag(
+                10,
+                10,
+                90,
+                50,
+                new PixelSize(100, 100),
+                new PixelSize(200, 200));
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(20, 20, 160, 80)));
+        }
+
+        [Test]
         public void FullSourceUsesEntireSourceBounds()
         {
             var selection = CropRectCalculator.FullSource(new PixelSize(320, 180));
@@ -90,6 +104,19 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
                 AspectRatioSpec.Square);
 
             Assert.That(selection, Is.EqualTo(new CropSelection(70, 50, 50, 50)));
+        }
+
+        [Test]
+        public void FreeManualInputKeepsIndependentWidthAndHeight()
+        {
+            var selection = CropRectCalculator.FromManualInput(
+                95,
+                95,
+                100,
+                50,
+                new PixelSize(120, 100));
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(20, 50, 100, 50)));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- Add Free to Crop Ratio presets
- Support unconstrained drag selection for Free mode
- Support unconstrained manual X / Y / W / H selection edits for Free mode
- Keep existing constrained ratio behavior unchanged
- Add EditMode tests for free drag and manual input

## Validation
- Unity 6000.4.0f1 EditMode tests on this repository: 24 passed, 0 failed
- Result XML: Validation/editmode-results.xml

Closes #39