### PR TITLE
Allow dragging selection to move it

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -30,6 +30,8 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
         private int _customOutputHeight = 1;
         private Vector2 _dragStartLocal;
         private Rect _dragImageRect;
+        private CropSelection _dragStartSelection;
+        private DragMode _dragMode = DragMode.None;
         private float _sourceZoom = 1f;
         private Vector2 _sourcePan;
         private bool _isDragging;
@@ -353,6 +355,8 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             {
                 _dragImageRect = imageRect;
                 _dragStartLocal = ClampLocalPoint(currentEvent.mousePosition - _dragImageRect.position, _dragImageRect);
+                _dragStartSelection = _selection;
+                _dragMode = IsMouseOverSelection(currentEvent.mousePosition, imageRect) ? DragMode.Move : DragMode.Create;
                 _isDragging = true;
                 currentEvent.Use();
             }
@@ -362,24 +366,36 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 var clampedMousePosition = ClampPointToRect(currentEvent.mousePosition, previewRect);
                 var localStart = ClampLocalPoint(_dragStartLocal, _dragImageRect);
                 var localEnd = ClampLocalPoint(clampedMousePosition - _dragImageRect.position, _dragImageRect);
-                var previewSize = new PixelSize(Mathf.RoundToInt(_dragImageRect.width), Mathf.RoundToInt(_dragImageRect.height));
                 var sourceSize = new PixelSize(_sourceTexture.width, _sourceTexture.height);
-                _selection = _cropPreset == AspectPreset.Free
-                    ? CropRectCalculator.FromPreviewDrag(
-                        localStart.x,
-                        localStart.y,
-                        localEnd.x,
-                        localEnd.y,
-                        previewSize,
-                        sourceSize)
-                    : CropRectCalculator.FromPreviewDrag(
-                        localStart.x,
-                        localStart.y,
-                        localEnd.x,
-                        localEnd.y,
-                        previewSize,
+                if (_dragMode == DragMode.Move && _dragStartSelection.IsValid)
+                {
+                    var delta = localEnd - localStart;
+                    _selection = CropRectCalculator.MoveSelection(
+                        _dragStartSelection,
                         sourceSize,
-                        GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                        delta.x * _sourceTexture.width / _dragImageRect.width,
+                        delta.y * _sourceTexture.height / _dragImageRect.height);
+                }
+                else
+                {
+                    var previewSize = new PixelSize(Mathf.RoundToInt(_dragImageRect.width), Mathf.RoundToInt(_dragImageRect.height));
+                    _selection = _cropPreset == AspectPreset.Free
+                        ? CropRectCalculator.FromPreviewDrag(
+                            localStart.x,
+                            localStart.y,
+                            localEnd.x,
+                            localEnd.y,
+                            previewSize,
+                            sourceSize)
+                        : CropRectCalculator.FromPreviewDrag(
+                            localStart.x,
+                            localStart.y,
+                            localEnd.x,
+                            localEnd.y,
+                            previewSize,
+                            sourceSize,
+                            GetAspectRatio(_cropPreset, _customCropWidth, _customCropHeight));
+                }
                 RefreshOutputPreview();
                 Repaint();
                 currentEvent.Use();
@@ -387,8 +403,19 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 if (currentEvent.type == EventType.MouseUp)
                 {
                     _isDragging = false;
+                    _dragMode = DragMode.None;
                 }
             }
+        }
+
+        private bool IsMouseOverSelection(Vector2 mousePosition, Rect imageRect)
+        {
+            if (!_selection.IsValid || _sourceTexture == null)
+            {
+                return false;
+            }
+
+            return GetSelectionRect(imageRect).Contains(mousePosition);
         }
 
         private static Vector2 ClampPointToRect(Vector2 point, Rect rect)
@@ -423,6 +450,15 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             Handles.color = SelectionColor;
             Handles.DrawAAPolyLine(3f, new Vector3(rect.xMin, rect.yMin), new Vector3(rect.xMax, rect.yMin), new Vector3(rect.xMax, rect.yMax), new Vector3(rect.xMin, rect.yMax), new Vector3(rect.xMin, rect.yMin));
             Handles.EndGUI();
+        }
+
+        private Rect GetSelectionRect(Rect imageRect)
+        {
+            var x = imageRect.x + imageRect.width * _selection.X / _sourceTexture.width;
+            var y = imageRect.y + imageRect.height * _selection.Y / _sourceTexture.height;
+            var width = imageRect.width * _selection.Width / _sourceTexture.width;
+            var height = imageRect.height * _selection.Height / _sourceTexture.height;
+            return new Rect(x, y, width, height);
         }
 
         private void RefreshOutputPreview()
@@ -712,6 +748,13 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             Landscape16By9,
             Portrait9By16,
             Custom
+        }
+
+        private enum DragMode
+        {
+            None,
+            Create,
+            Move
         }
     }
 }

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/CropRectCalculator.cs
@@ -114,6 +114,25 @@ namespace Sunmax0731.SquareCropEditor.Services
             return new CropSelection(clampedX, clampedY, clampedWidth, clampedHeight);
         }
 
+        public static CropSelection MoveSelection(CropSelection selection, PixelSize sourceSize, double deltaX, double deltaY)
+        {
+            if (!selection.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(selection), "Selection must be positive.");
+            }
+
+            if (!sourceSize.IsValid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceSize), "Source size must be positive.");
+            }
+
+            var x = (int)Math.Round(selection.X + deltaX);
+            var y = (int)Math.Round(selection.Y + deltaY);
+            x = Math.Max(0, Math.Min(x, sourceSize.Width - selection.Width));
+            y = Math.Max(0, Math.Min(y, sourceSize.Height - selection.Height));
+            return new CropSelection(x, y, selection.Width, selection.Height);
+        }
+
         public static CropSelection FromPreviewDrag(
             double startX,
             double startY,

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -120,6 +120,18 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void MoveSelectionKeepsSizeAndClampsToBounds()
+        {
+            var selection = CropRectCalculator.MoveSelection(
+                new CropSelection(80, 80, 30, 20),
+                new PixelSize(100, 100),
+                50,
+                50);
+
+            Assert.That(selection, Is.EqualTo(new CropSelection(70, 80, 30, 20)));
+        }
+
+        [Test]
         public void FitMapsFullSourceInsideTransparentCanvasArea()
         {
             var plan = AspectOutputPlanner.Plan(


### PR DESCRIPTION
## Summary
- Detect MouseDown inside the existing selection and enter move mode
- Move the selection while preserving width and height
- Clamp moved selection to source bounds
- Keep outside-selection drag behavior as new selection creation
- Add EditMode coverage for move clamping

## Validation
- Unity 6000.4.0f1 EditMode tests on this repository: 25 passed, 0 failed
- Result XML: Validation/editmode-results.xml

Closes #40