### PR TITLE
Add Output padding setting

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Localization/SquareCropLocalization.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Localization/SquareCropLocalization.cs
@@ -23,6 +23,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Localization
             ["cropRatio"] = "Crop比率",
             ["outputRatio"] = "Output比率",
             ["outputLongEdge"] = "Output長辺",
+            ["outputPadding"] = "Output余白",
             ["mapping"] = "配置",
             ["conflict"] = "競合",
             ["outputFolder"] = "出力フォルダ",

--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -293,6 +293,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
         private void DrawOutputControls()
         {
             _settings.OutputSize = Mathf.Max(1, EditorGUILayout.IntField(T("outputLongEdge", "Output Long Edge"), _settings.OutputSize));
+            _settings.OutputPadding = Mathf.Max(0, EditorGUILayout.IntField(T("outputPadding", "Output Padding"), _settings.OutputPadding));
             _settings.MappingMode = (CanvasMappingMode)EditorGUILayout.EnumPopup(T("mapping", "Mapping"), _settings.MappingMode);
             _settings.ConflictBehavior = (ExportConflictBehavior)EditorGUILayout.EnumPopup(T("conflict", "Conflict"), _settings.ConflictBehavior);
 
@@ -606,7 +607,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 try
                 {
                     var outputSize = AspectOutputPlanner.CalculateOutputSize(_settings.OutputSize, GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight));
-                    var plan = AspectOutputPlanner.Plan(_selection, outputSize, _settings.MappingMode);
+                    var plan = AspectOutputPlanner.Plan(_selection, outputSize, _settings.MappingMode, _settings.OutputPadding);
                     _outputPreview = PngAspectExporter.Render(readable.Texture, plan);
                     SetStatus(readable.OwnsTexture
                         ? TFormat("status.selectionTemporaryReadable", "Selection: {0} x {1}. Using temporary readable copy.", _selection.Width, _selection.Height)
@@ -646,6 +647,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                     SourceTexture = readable.Texture,
                     Selection = _selection,
                     OutputLongEdge = _settings.OutputSize,
+                    OutputPadding = _settings.OutputPadding,
                     OutputAspectRatio = GetAspectRatio(_outputPreset, _customOutputWidth, _customOutputHeight),
                     MappingMode = _settings.MappingMode,
                     OutputFolder = _settings.OutputFolder,
@@ -684,6 +686,7 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
             var message = new StringBuilder()
                 .AppendLine($"{T("dialog.output", "Output")}: {outputSize.Width} x {outputSize.Height}")
                 .AppendLine($"{T("dialog.selection", "Selection")}: {_selection.X}, {_selection.Y}, {_selection.Width} x {_selection.Height}")
+                .AppendLine($"{T("outputPadding", "Output Padding")}: {_settings.OutputPadding}px")
                 .AppendLine($"{T("dialog.mapping", "Mapping")}: {_settings.MappingMode}")
                 .AppendLine($"{T("dialog.conflict", "Conflict")}: {_settings.ConflictBehavior}")
                 .AppendLine()

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/PngExportRequest.cs
@@ -12,6 +12,8 @@ namespace Sunmax0731.SquareCropEditor.Models
 
         public int OutputLongEdge { get; set; } = SquareCropSettings.DefaultOutputSize;
 
+        public int OutputPadding { get; set; }
+
         public AspectRatioSpec OutputAspectRatio { get; set; } = AspectRatioSpec.Square;
 
         public CanvasMappingMode MappingMode { get; set; } = CanvasMappingMode.Fit;

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Models/SquareCropSettings.cs
@@ -15,6 +15,8 @@ namespace Sunmax0731.SquareCropEditor.Models
 
         public int OutputSize { get; set; } = DefaultOutputSize;
 
+        public int OutputPadding { get; set; }
+
         public CanvasMappingMode MappingMode { get; set; } = CanvasMappingMode.Fit;
 
         public string OutputFolder { get; set; } = DefaultOutputFolder;

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/AspectOutputPlanner.cs
@@ -27,16 +27,26 @@ namespace Sunmax0731.SquareCropEditor.Services
 
         public static OutputMappingPlan Plan(CropSelection selection, int outputLongEdge, AspectRatioSpec outputAspectRatio, CanvasMappingMode mappingMode)
         {
+            return Plan(selection, outputLongEdge, outputAspectRatio, mappingMode, 0);
+        }
+
+        public static OutputMappingPlan Plan(CropSelection selection, int outputLongEdge, AspectRatioSpec outputAspectRatio, CanvasMappingMode mappingMode, int outputPadding)
+        {
             if (!selection.IsValid)
             {
                 throw new ArgumentOutOfRangeException(nameof(selection), "Selection must be positive.");
             }
 
             var outputSize = CalculateOutputSize(outputLongEdge, outputAspectRatio);
-            return Plan(selection, outputSize, mappingMode);
+            return Plan(selection, outputSize, mappingMode, outputPadding);
         }
 
         public static OutputMappingPlan Plan(CropSelection selection, PixelSize outputSize, CanvasMappingMode mappingMode)
+        {
+            return Plan(selection, outputSize, mappingMode, 0);
+        }
+
+        public static OutputMappingPlan Plan(CropSelection selection, PixelSize outputSize, CanvasMappingMode mappingMode, int outputPadding)
         {
             if (!selection.IsValid)
             {
@@ -48,30 +58,42 @@ namespace Sunmax0731.SquareCropEditor.Services
                 throw new ArgumentOutOfRangeException(nameof(outputSize), "Output size must be positive.");
             }
 
+            var contentRect = CalculateContentRect(outputSize, outputPadding);
             switch (mappingMode)
             {
                 case CanvasMappingMode.Fit:
-                    return PlanFit(selection, outputSize);
+                    return PlanFit(selection, outputSize, contentRect);
                 case CanvasMappingMode.Fill:
-                    return PlanFill(selection, outputSize);
+                    return PlanFill(selection, outputSize, contentRect);
                 case CanvasMappingMode.Stretch:
                     return new OutputMappingPlan(
                         outputSize,
                         selection,
-                        new CropSelection(0, 0, outputSize.Width, outputSize.Height),
+                        contentRect,
                         CanvasMappingMode.Stretch);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mappingMode), mappingMode, "Unsupported mapping mode.");
             }
         }
 
-        private static OutputMappingPlan PlanFit(CropSelection selection, PixelSize outputSize)
+        private static CropSelection CalculateContentRect(PixelSize outputSize, int outputPadding)
         {
-            var scale = Math.Min((double)outputSize.Width / selection.Width, (double)outputSize.Height / selection.Height);
+            var maxPadding = Math.Max(0, Math.Min((outputSize.Width - 1) / 2, (outputSize.Height - 1) / 2));
+            var padding = Math.Min(Math.Max(0, outputPadding), maxPadding);
+            return new CropSelection(
+                padding,
+                padding,
+                outputSize.Width - padding * 2,
+                outputSize.Height - padding * 2);
+        }
+
+        private static OutputMappingPlan PlanFit(CropSelection selection, PixelSize outputSize, CropSelection contentRect)
+        {
+            var scale = Math.Min((double)contentRect.Width / selection.Width, (double)contentRect.Height / selection.Height);
             var destinationWidth = Math.Max(1, (int)Math.Round(selection.Width * scale));
             var destinationHeight = Math.Max(1, (int)Math.Round(selection.Height * scale));
-            var destinationX = (outputSize.Width - destinationWidth) / 2;
-            var destinationY = (outputSize.Height - destinationHeight) / 2;
+            var destinationX = contentRect.X + (contentRect.Width - destinationWidth) / 2;
+            var destinationY = contentRect.Y + (contentRect.Height - destinationHeight) / 2;
 
             return new OutputMappingPlan(
                 outputSize,
@@ -80,9 +102,9 @@ namespace Sunmax0731.SquareCropEditor.Services
                 CanvasMappingMode.Fit);
         }
 
-        private static OutputMappingPlan PlanFill(CropSelection selection, PixelSize outputSize)
+        private static OutputMappingPlan PlanFill(CropSelection selection, PixelSize outputSize, CropSelection contentRect)
         {
-            var outputRatio = (double)outputSize.Width / outputSize.Height;
+            var outputRatio = (double)contentRect.Width / contentRect.Height;
             var sourceRatio = (double)selection.Width / selection.Height;
 
             var sourceX = selection.X;
@@ -104,7 +126,7 @@ namespace Sunmax0731.SquareCropEditor.Services
             return new OutputMappingPlan(
                 outputSize,
                 new CropSelection(sourceX, sourceY, sourceWidth, sourceHeight),
-                new CropSelection(0, 0, outputSize.Width, outputSize.Height),
+                contentRect,
                 CanvasMappingMode.Fill);
         }
     }

--- a/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Runtime/Services/PngAspectExporter.cs
@@ -26,7 +26,7 @@ namespace Sunmax0731.SquareCropEditor.Services
 
             try
             {
-                var plan = AspectOutputPlanner.Plan(request.Selection, outputSize, request.MappingMode);
+                var plan = AspectOutputPlanner.Plan(request.Selection, outputSize, request.MappingMode, request.OutputPadding);
                 var outputTexture = Render(request.SourceTexture, plan);
                 var pngBytes = ImageConversion.EncodeToPNG(outputTexture);
                 UnityEngine.Object.DestroyImmediate(outputTexture);
@@ -107,6 +107,11 @@ namespace Sunmax0731.SquareCropEditor.Services
             if (request.OutputLongEdge <= 0)
             {
                 return "Output size must be positive.";
+            }
+
+            if (request.OutputPadding < 0)
+            {
+                return "Output padding must be zero or greater.";
             }
 
             if (!request.OutputAspectRatio.IsValid)

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/AspectMappingTests.cs
@@ -144,6 +144,20 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void FitMapsSelectionInsideOutputPadding()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(0, 0, 200, 100),
+                new PixelSize(256, 256),
+                CanvasMappingMode.Fit,
+                16);
+
+            Assert.That(plan.OutputSize, Is.EqualTo(new PixelSize(256, 256)));
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(0, 0, 200, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(16, 72, 224, 112)));
+        }
+
+        [Test]
         public void FillCropsSourceToOutputRatio()
         {
             var plan = AspectOutputPlanner.Plan(
@@ -156,6 +170,19 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void FillUsesPaddedContentArea()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(0, 0, 200, 100),
+                new PixelSize(256, 256),
+                CanvasMappingMode.Fill,
+                16);
+
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(50, 0, 100, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(16, 16, 224, 224)));
+        }
+
+        [Test]
         public void StretchUsesFullSourceAndFullCanvas()
         {
             var plan = AspectOutputPlanner.Plan(
@@ -165,6 +192,31 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
 
             Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(10, 20, 200, 100)));
             Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(0, 0, 256, 144)));
+        }
+
+        [Test]
+        public void StretchUsesPaddedContentArea()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(10, 20, 200, 100),
+                new PixelSize(256, 144),
+                CanvasMappingMode.Stretch,
+                12);
+
+            Assert.That(plan.SourceRect, Is.EqualTo(new CropSelection(10, 20, 200, 100)));
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(12, 12, 232, 120)));
+        }
+
+        [Test]
+        public void PaddingIsClampedToKeepContentAreaPositive()
+        {
+            var plan = AspectOutputPlanner.Plan(
+                new CropSelection(0, 0, 10, 10),
+                new PixelSize(16, 16),
+                CanvasMappingMode.Stretch,
+                100);
+
+            Assert.That(plan.DestinationRect, Is.EqualTo(new CropSelection(7, 7, 2, 2)));
         }
     }
 }

--- a/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Tests/Editor/PngAspectExporterTests.cs
@@ -73,6 +73,23 @@ namespace Sunmax0731.SquareCropEditor.Tests.Editor
         }
 
         [Test]
+        public void OutputPaddingLeavesTransparentBorder()
+        {
+            var source = CreateSourceTexture();
+            var output = PngAspectExporter.Render(
+                source,
+                AspectOutputPlanner.Plan(new CropSelection(0, 0, 4, 4), new PixelSize(8, 8), CanvasMappingMode.Stretch, 2));
+
+            Assert.That(output.GetPixel(0, 0).a, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(output.GetPixel(7, 7).a, Is.EqualTo(0f).Within(0.001f));
+            Assert.That(output.GetPixel(2, 2).a, Is.GreaterThan(0f));
+            Assert.That(output.GetPixel(5, 5).a, Is.GreaterThan(0f));
+
+            UnityEngine.Object.DestroyImmediate(source);
+            UnityEngine.Object.DestroyImmediate(output);
+        }
+
+        [Test]
         public void ExportPreservesSourceAlpha()
         {
             var source = CreateSourceTexture();


### PR DESCRIPTION
## Summary
- add Output Padding setting in pixels
- apply padding to preview and PNG export by mapping into the padded content area
- keep Padding 0 behavior compatible with existing output mapping
- add tests for Fit, Fill, Stretch, padding clamping, and transparent rendered borders

## Validation
- Unity 6000.4.0f1 EditMode tests on temp project copy: 32 passed / 0 failed

Closes #52