### PR TITLE
Restore numeric Source pan controls

### DIFF
--- a/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
+++ b/Packages/com.sunmax0731.square-crop-editor/Editor/Windows/SquareCropEditorWindow.cs
@@ -444,6 +444,15 @@ namespace Sunmax0731.SquareCropEditor.Editor.Windows
                 }
             }
 
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (new EditorGUI.DisabledScope(_sourceTexture == null || _sourceZoom <= 1f))
+                {
+                    _sourcePan.x = Mathf.Clamp(EditorGUILayout.FloatField(T("panX", "Pan X"), _sourcePan.x), -1f, 1f);
+                    _sourcePan.y = Mathf.Clamp(EditorGUILayout.FloatField(T("panY", "Pan Y"), _sourcePan.y), -1f, 1f);
+                }
+            }
+
             if (_sourceZoom <= 1f)
             {
                 _sourcePan = Vector2.zero;


### PR DESCRIPTION
## Summary
- keep the zoomed Source preview scrollbars
- add Pan X / Pan Y numeric FloatFields back to Source view controls
- clamp numeric pan values to the same -1..1 range used by scrollbars

## Validation
- Unity 6000.4.0f1 EditMode tests on temp project copy: 32 passed / 0 failed

Closes #54